### PR TITLE
Add documentation for running Couscous in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ php:
 
 before_script:
   - composer install --no-progress
+  - npm install -g less
+  - npm install -g less-plugin-clean-css
 
 script:
   - phpunit
+
+after_script:
+  - bin/couscous deploy


### PR DESCRIPTION
## [WiP] for task #34

This PR solves a little problem while running travis builds as less and less-plugin-clean-css packages were missing.

To safely deploy with couscus from a travis build we need to take this things into consideration:
- [ ] Make sure the deployment is running only for master.
- [ ] Make sure it is not a pull request.
- [ ] Make sure we deploy once per build. E.G. don't deploy for every PHP version tested :smile:
- [x] Decide what to use to deploy: [Private Key](http://stackoverflow.com/questions/23277391/pushing-to-github-from-travis-ci) or [Personal Access Token](http://stackoverflow.com/questions/18027115/committing-via-travis-ci-failing)  
  - More info on [Personal Access Token](https://medium.com/@nthgergo/publishing-gh-pages-with-travis-ci-53a8270e87db)

You can have a look at the latest builds of my fork in [travis-ci](https://travis-ci.org/lombartec/Couscous/builds) to see more or less what happened

Feel free to add commits and keep working on this together.
