### PR TITLE
Deploy gh-pages branch from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,19 @@ php:
 
 before_script:
   - composer install --no-progress
+  - npm install -g less
+  - npm install -g less-plugin-clean-css
 
 script:
   - phpunit
+
+after_success:
+  - php bin/couscous generate
+  - sh bin/deploy.sh
+
+env:
+  global:
+  - GIT_NAME: CouscousPHP Auto Deploy
+  - GIT_EMAIL: test@couscousphp.io
+  - GH_REF: github.com/lombartec/Couscous
+  - secure: vpbd+T1eTHwlXaQHPeuTReQ34CgyyI+ZR8ZswE3eBxK2jkLa653r3J7RTfUVC5X73bT12PT2I+SrGpDcROCGDx/b0CnKNsn7fpcvSHxlWEm0neRp7N1NYwpVbzjwVlLSrCqKCQf3VsmuXAZAim+JxHMGV4+pnW73Z0pnsJWS22U=

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+if [ ! "$TRAVIS_BRANCH" = "master" ]
+then
+    echo "[NOT DEPLOYED] Current branch is not master"
+    exit 1
+fi
+
+if [ ! "$TRAVIS_PULL_REQUEST" = false ]
+then
+    echo "[NOT DEPLOYED] Not pushing documentation for pull requests"
+    exit 1
+fi
+
+mkdir out
+echo "Starting deploy..."
+(
+cd out
+git init
+git config user.name ${GIT_NAME}
+git config user.email ${GIT_EMAIL}
+cp ../website/* ./
+git add .
+git commit -m "Deployed to Github Pages"
+git push --force "https://${GH_TOKEN}@${GH_REF}" master:gh-pages
+)

--- a/couscous.yml
+++ b/couscous.yml
@@ -7,7 +7,7 @@ exclude:
   - tests
 
 before:
-  - bin/compile
+  - php bin/compile
   - cp bin/couscous.phar website/
   - lessc --clean-css website/less/main.less website/css/all.min.css
 


### PR DESCRIPTION
## [WiP] for task #34

To safely deploy with couscus from a travis build we need to take this things into consideration:
- [x] Make sure the deployment is running only for master.
- [x] Make sure it is not a pull request.
- [ ] Make sure we deploy once per build. E.G. don't deploy for every PHP version tested :smile:
- [x] Decide what to use to deploy: [Private Key](http://stackoverflow.com/questions/23277391/pushing-to-github-from-travis-ci) or [Personal Access Token](http://stackoverflow.com/questions/18027115/committing-via-travis-ci-failing)  
  - More info on [Personal Access Token](https://medium.com/@nthgergo/publishing-gh-pages-with-travis-ci-53a8270e87db)

Step by step to achieve the deploy:

Terminology:
- **PAT** = Personal Access Token
1. Install Travis on CLI `$gem install travis`
2. `$travis login` in the repo directory, this is needed to encrypt the **PAT**.
3. Generate a **PAT** from your GitHub account: Settings >> Applications >> Personal Access Token  
   3.1 Giving it `public_repo` permission should be enough.
4. `$travis encrypt GH_TOKEN=PERSONALACCESSTOKENHERE --add`  
   4.1 The `--add` flag will automatically write the encrypted string to your `.travis.yml` file.

Feel free to add commits and keep working on this together.
