### PR TITLE
Documentation for Metadata

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -30,6 +30,9 @@ menu:
         templates:
             text: Templates
             relativeUrl: docs/templates.html
+        metadata:
+            text: Metadata
+            relativeUrl: docs/metadata.html
         faq:
             text: FAQ
             relativeUrl: docs/faq.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This is the documentation root. Here are some articles to help you:
 - [Getting started](getting-started.md)
 - [Configuration using `couscous.yml`](configuration.md)
 - [Writing templates](templates.md)
+- [Metadata](metadata.md)
 - [FAQ](faq.md)
 - [Contributing](../CONTRIBUTING.md)
 - [Change log](../CHANGELOG.html)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,5 +39,4 @@ title: Hello!
 baseUrl: http://username.github.io/your-project
 ```
 
-**Note:** any variable you put in the `couscous.yml` is available in templates.
-You can use this to define the website's title for example, or any global variable.
+**Note:** any variable you put in `couscous.yml` is called **Metadata**. You can use these variables in templates for example. Learn more about this in the [Metadata documentation](metadata.md).

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -1,0 +1,45 @@
+---
+current_menu: metadata
+---
+# Metadata
+
+In Couscous, there are 2 kinds of data:
+
+- **file content** (e.g. Markdown, HTML, …)
+- **metadata**, which is simply an array of variables
+
+Metadata can contain any kind of value and can be attached to:
+
+- the whole project
+- a specific file
+
+Metadata is used by Couscous to customize the generation process and by templates to customize their content.
+
+## Defining metadata
+
+**Project** metadata is defined in `couscous.yml`. For example:
+
+```yaml
+template:
+    directory: website
+title: The website title!
+```
+
+**File** metadata is defined using YAML front matter (at the top of Markdown files):
+
+```markdown
+---
+category: "Star Wars"
+---
+This is my documentation.
+```
+
+However, Couscous will also define both **project and file metadata** while generating the website. For example, when parsing Markdown files, it will define the `content` variable (to contain the generated HTML content for the current file).
+
+## Metadata reference
+
+Here is a list of **all metadata variables automatically defined by Couscous**:
+
+- `content`: contains the generated HTML content of the current file (Markdown turned to HTML)
+
+Remember everything you defined in `couscous.yml` or in YAML front matter is also available.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -3,7 +3,6 @@ current_menu: templates
 ---
 # Templates
 
-
 ## Remote templates
 
 A **remote template** is a template that is hosted separately in a git repository.
@@ -21,7 +20,6 @@ The [Basic](https://github.com/CouscousPHP/Template-Basic) template is a good wa
 template:
     directory: .
 ```
-
 
 ## Embedded templates
 
@@ -79,9 +77,9 @@ This is my documentation.
 This is a *sub-chapter*.
 ```
 
-### Variables
+### Variables (aka Metadata)
 
-Variables can be defined in:
+Custom variables, called [**Metadata**](metadata.md), can be defined in:
 
 - `couscous.yml`
 - YAML front matter (at the top of Markdown files)
@@ -118,9 +116,7 @@ This is my documentation.
 </html>
 ```
 
-You can even override `couscous.yml` variables from the Markdown files's front matter (e.g. overriding the page title).
-
-Have a look at the [Light template](https://github.com/CouscousPHP/Template-Light): it uses variables to build a sidebar menu.
+To learn more, read the whole [Metadata documentation](metadata.md).
 
 ### Links
 


### PR DESCRIPTION
Added a new documentation article to explain what Metadata is, and show a reference of all Metadata variables that can be used in templates.

I think that will be useful for people writing templates, especially with #69: they can have a list of all available variables.

I'm opening this as a PR for review if anybody has comments, I'll be merging it soon for #69.
