### PR TITLE
Introduced a logger to replace usage of OutputInterface by LoggerInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,9 @@ interface Step
     /**
      * Process the given repository.
      *
-     * @param Repository      $repository
-     * @param OutputInterface $output     Output for the user.
+     * @param Repository $repository
      */
-    public function __invoke(Repository $repository, OutputInterface $output);
+    public function __invoke(Repository $repository);
 }
 ```
 
@@ -49,7 +48,7 @@ For example, here is a step that would preprocess Markdown files to put the word
 ```php
 class PutCouscousInBold implements \Couscous\Step
 {
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         /** @var MarkdownFile[] $markdownFiles */
         $markdownFiles = $repository->findFilesByType('Couscous\Model\MarkdownFile');

--- a/bin/couscous
+++ b/bin/couscous
@@ -8,6 +8,7 @@
 
 use Couscous\Application\ContainerFactory;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 if (version_compare(phpversion(), '5.4', '<')) {
     die('You must use PHP >= 5.4 in order to use Couscous. Please upgrade your PHP version.');
@@ -22,8 +23,16 @@ if (isset($include)) {
     require_once __DIR__ . '/../../../autoload.php';
 }
 
+$output = new ConsoleOutput();
+
 $factory = new ContainerFactory();
 $container = $factory->createContainer();
+
+// Set the logger
+$logger = $container->make('Symfony\Component\Console\Logger\ConsoleLogger', [
+    'output' => $output,
+]);
+$container->set('Psr\Log\LoggerInterface', $logger);
 
 /** @var Application $application */
 $application = $container->get('application');

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "erusev/parsedown-extra": "~0.2.0",
         "phine/phar": "~1.0",
         "mnapoli/front-yaml": "~1.0",
-        "mnapoli/php-di": "~4.4"
+        "mnapoli/php-di": "~4.4",
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3"

--- a/src/Application/Cli/PreviewCommand.php
+++ b/src/Application/Cli/PreviewCommand.php
@@ -119,7 +119,7 @@ class PreviewCommand extends Command
         $process = $builder->getProcess();
         $process->start();
 
-        $output->writeln(sprintf("Server running on <info>%s</info>", $input->getArgument('address')));
+        $output->writeln(sprintf("Server running on <comment>%s</comment>", $input->getArgument('address')));
     }
 
     private function isSupported()

--- a/src/Application/ContainerFactory.php
+++ b/src/Application/ContainerFactory.php
@@ -2,8 +2,8 @@
 
 namespace Couscous\Application;
 
+use DI\Container;
 use DI\ContainerBuilder;
-use Interop\Container\ContainerInterface;
 
 /**
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
@@ -11,7 +11,7 @@ use Interop\Container\ContainerInterface;
 class ContainerFactory
 {
     /**
-     * @return ContainerInterface
+     * @return Container
      */
     public function createContainer()
     {

--- a/src/Application/config.php
+++ b/src/Application/config.php
@@ -1,7 +1,9 @@
 <?php
 
 use Interop\Container\ContainerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Output\OutputInterface;
 
 return [
 
@@ -37,7 +39,7 @@ return [
     }),
 
     'application' => DI\factory(function (ContainerInterface $c) {
-        $application = new Application('Couscous', '1.0-dev');
+        $application = new Application('Couscous');
 
         $application->add($c->get('Couscous\Application\Cli\GenerateCommand'));
         $application->add($c->get('Couscous\Application\Cli\PreviewCommand'));
@@ -51,5 +53,18 @@ return [
         ->constructorParameter('markdownParser', DI\link('Mni\FrontYAML\Markdown\MarkdownParser')),
     'Mni\FrontYAML\Markdown\MarkdownParser' => DI\object('Mni\FrontYAML\Bridge\Parsedown\ParsedownParser')
         ->constructor(DI\link('ParsedownExtra')),
+
+    'Symfony\Component\Console\Logger\ConsoleLogger' => DI\object()
+        ->constructorParameter('verbosityLevelMap', [
+            // Custom verbosity map
+            LogLevel::EMERGENCY => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::ALERT => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::CRITICAL => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::ERROR => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::WARNING => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::NOTICE => OutputInterface::VERBOSITY_NORMAL,
+            LogLevel::INFO => OutputInterface::VERBOSITY_VERBOSE,
+            LogLevel::DEBUG => OutputInterface::VERBOSITY_VERY_VERBOSE,
+        ]),
 
 ];

--- a/src/Module/Bower/Step/RunBowerInstall.php
+++ b/src/Module/Bower/Step/RunBowerInstall.php
@@ -5,7 +5,7 @@ namespace Couscous\Module\Bower\Step;
 use Couscous\CommandRunner\CommandRunner;
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -25,19 +25,28 @@ class RunBowerInstall implements Step
      */
     private $commandRunner;
 
-    public function __construct(Filesystem $filesystem, CommandRunner $commandRunner)
-    {
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        Filesystem $filesystem,
+        CommandRunner $commandRunner,
+        LoggerInterface $logger
+    ) {
         $this->filesystem = $filesystem;
         $this->commandRunner = $commandRunner;
+        $this->logger = $logger;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
-        if ($repository->regenerate || !$this->hasBowerJson($repository)) {
+        if ($repository->regenerate || ! $this->hasBowerJson($repository)) {
             return;
         }
 
-        $output->writeln('Executing <info>bower install</info>');
+        $this->logger->notice('Executing "bower install"');
 
         $result = $this->commandRunner->run(sprintf(
             'cd "%s" && bower install',
@@ -45,7 +54,7 @@ class RunBowerInstall implements Step
         ));
 
         if ($result) {
-            $output->writeln($result);
+            $this->logger->info($result);
         }
     }
 

--- a/src/Module/Config/Step/LoadConfig.php
+++ b/src/Module/Config/Step/LoadConfig.php
@@ -4,7 +4,7 @@ namespace Couscous\Module\Config\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
@@ -28,18 +28,24 @@ class LoadConfig implements Step
      */
     private $yamlParser;
 
-    public function __construct(Filesystem $filesystem, Parser $yamlParser)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(Filesystem $filesystem, Parser $yamlParser, LoggerInterface $logger)
     {
         $this->filesystem = $filesystem;
         $this->yamlParser = $yamlParser;
+        $this->logger     = $logger;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         $filename = $repository->sourceDirectory . '/' . self::FILENAME;
 
         if (! $this->filesystem->exists($filename)) {
-            $output->writeln("<comment>No couscous.yml configuration file found, using default config</comment>");
+            $this->logger->notice('No couscous.yml configuration file found, using default config');
             return;
         }
 

--- a/src/Module/Config/Step/OverrideBaseUrlForPreview.php
+++ b/src/Module/Config/Step/OverrideBaseUrlForPreview.php
@@ -3,8 +3,6 @@
 namespace Couscous\Module\Config\Step;
 
 use Couscous\Model\Repository;
-use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Override the baseUrl if we are in preview.
@@ -13,7 +11,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class OverrideBaseUrlForPreview implements \Couscous\Step
 {
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         if ($repository->metadata['preview'] === true) {
             $repository->metadata['baseUrl'] = '';

--- a/src/Module/Config/Step/SetDefaultConfig.php
+++ b/src/Module/Config/Step/SetDefaultConfig.php
@@ -4,7 +4,6 @@ namespace Couscous\Module\Config\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Set the default config.
@@ -19,7 +18,7 @@ class SetDefaultConfig implements Step
         ],
     ];
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         $repository->metadata->setMany($this->defaultConfig);
     }

--- a/src/Module/Core/Step/ClearTargetDirectory.php
+++ b/src/Module/Core/Step/ClearTargetDirectory.php
@@ -4,7 +4,6 @@ namespace Couscous\Module\Core\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
@@ -25,7 +24,7 @@ class ClearTargetDirectory implements Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         $files = new Finder();
         $files->in($repository->targetDirectory);

--- a/src/Module/Core/Step/WriteFiles.php
+++ b/src/Module/Core/Step/WriteFiles.php
@@ -4,7 +4,7 @@ namespace Couscous\Module\Core\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -19,27 +19,31 @@ class WriteFiles implements Step
      */
     private $filesystem;
 
-    public function __construct(Filesystem $filesystem)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(Filesystem $filesystem, LoggerInterface $logger)
     {
         $this->filesystem = $filesystem;
+        $this->logger     = $logger;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         foreach ($repository->getFiles() as $file) {
             $targetFilename = $repository->targetDirectory . '/' . $file->relativeFilename;
 
-            if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-                $output->writeln("Writing $targetFilename");
-            }
-
             if ($this->filesystem->exists($targetFilename)) {
-                $output->writeln(sprintf(
-                    "<comment>Skipping '%s' because a file with the same name already exists</comment>",
-                    $file->relativeFilename
-                ));
+                $this->logger->info(
+                    "Skipping '{file}' because a file with the same name already exists",
+                    ['file' => $file->relativeFilename]
+                );
                 continue;
             }
+
+            $this->logger->debug('Writing {file}', ['file' => $targetFilename]);
 
             $this->filesystem->dumpFile($targetFilename, $file->getContent());
         }

--- a/src/Module/Markdown/Step/LoadMarkdownFiles.php
+++ b/src/Module/Markdown/Step/LoadMarkdownFiles.php
@@ -5,7 +5,6 @@ namespace Couscous\Module\Markdown\Step;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
@@ -13,9 +12,9 @@ use Symfony\Component\Finder\SplFileInfo;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class LoadMarkdownFiles implements \Couscous\Step
+class LoadMarkdownFiles implements Step
 {
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         $files = $repository->sourceFiles();
         $files->name('*.md');

--- a/src/Module/Markdown/Step/ParseMarkdownFrontMatter.php
+++ b/src/Module/Markdown/Step/ParseMarkdownFrontMatter.php
@@ -6,14 +6,13 @@ use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
 use Mni\FrontYAML\Parser;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Parse Markdown front matter to load file metadata.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ParseMarkdownFrontMatter implements \Couscous\Step
+class ParseMarkdownFrontMatter implements Step
 {
     /**
      * @var Parser
@@ -25,7 +24,7 @@ class ParseMarkdownFrontMatter implements \Couscous\Step
         $this->markdownParser = $markdownParser;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         /** @var MarkdownFile[] $markdownFiles */
         $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');

--- a/src/Module/Markdown/Step/ProcessMarkdownFileName.php
+++ b/src/Module/Markdown/Step/ProcessMarkdownFileName.php
@@ -5,16 +5,15 @@ namespace Couscous\Module\Markdown\Step;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Processes the name of Markdown files.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ProcessMarkdownFileName implements \Couscous\Step
+class ProcessMarkdownFileName implements Step
 {
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         /** @var MarkdownFile[] $markdownFiles */
         $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');

--- a/src/Module/Markdown/Step/RenderMarkdown.php
+++ b/src/Module/Markdown/Step/RenderMarkdown.php
@@ -7,14 +7,13 @@ use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
 use Mni\FrontYAML\Parser;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Turns Markdown to HTML.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class RenderMarkdown implements \Couscous\Step
+class RenderMarkdown implements Step
 {
     /**
      * @var Parser
@@ -26,7 +25,7 @@ class RenderMarkdown implements \Couscous\Step
         $this->markdownParser = $markdownParser;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         /** @var MarkdownFile[] $markdownFiles */
         $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');

--- a/src/Module/Markdown/Step/RewriteMarkdownLinks.php
+++ b/src/Module/Markdown/Step/RewriteMarkdownLinks.php
@@ -5,7 +5,6 @@ namespace Couscous\Module\Markdown\Step;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Rewrites links from *.md to *.html.
@@ -18,7 +17,7 @@ class RewriteMarkdownLinks implements Step
     const MARKDOWN_LINK_REGEX = '#\[([^\]]+)\]\(([^\)]+)\.md\)#';
     const REGEX_REPLACEMENT   = '[$1]($2.html)';
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         /** @var MarkdownFile[] $markdownFiles */
         $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');

--- a/src/Module/Scripts/Step/ExecuteAfterScripts.php
+++ b/src/Module/Scripts/Step/ExecuteAfterScripts.php
@@ -4,19 +4,18 @@ namespace Couscous\Module\Scripts\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Execute the scripts that were set in "scripts.after" in the configuration.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ExecuteAfterScripts extends ExecuteScripts implements \Couscous\Step
+class ExecuteAfterScripts extends ExecuteScripts implements Step
 {
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         $scripts = $repository->metadata['scripts.after'];
 
-        $this->executeScripts($scripts, $repository, $output);
+        $this->executeScripts($scripts, $repository);
     }
 }

--- a/src/Module/Scripts/Step/ExecuteBeforeScripts.php
+++ b/src/Module/Scripts/Step/ExecuteBeforeScripts.php
@@ -4,19 +4,18 @@ namespace Couscous\Module\Scripts\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Execute the scripts that were set in "scripts.before" in the configuration.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ExecuteBeforeScripts extends ExecuteScripts implements \Couscous\Step
+class ExecuteBeforeScripts extends ExecuteScripts implements Step
 {
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         $scripts = $repository->metadata['scripts.before'];
 
-        $this->executeScripts($scripts, $repository, $output);
+        $this->executeScripts($scripts, $repository);
     }
 }

--- a/src/Module/Scripts/Step/ExecuteScripts.php
+++ b/src/Module/Scripts/Step/ExecuteScripts.php
@@ -5,7 +5,7 @@ namespace Couscous\Module\Scripts\Step;
 use Couscous\CommandRunner\CommandException;
 use Couscous\CommandRunner\CommandRunner;
 use Couscous\Model\Repository;
-use Symfony\Component\Console\Output\OutputInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Base class.
@@ -19,27 +19,33 @@ abstract class ExecuteScripts
      */
     private $commandRunner;
 
-    public function __construct(CommandRunner $commandRunner)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(CommandRunner $commandRunner, LoggerInterface $logger)
     {
         $this->commandRunner = $commandRunner;
+        $this->logger        = $logger;
     }
 
-    protected function executeScripts($scripts, Repository $repository, OutputInterface $output)
+    protected function executeScripts($scripts, Repository $repository)
     {
         if (empty($scripts)) {
             return;
         }
 
         foreach ($scripts as $script) {
-            $this->executeScript($output, $repository->sourceDirectory, $script);
+            $this->executeScript($repository->sourceDirectory, $script);
         }
     }
 
-    private function executeScript(OutputInterface $output, $sourceDirectory, $script)
+    private function executeScript($sourceDirectory, $script)
     {
         $script = 'cd "' . $sourceDirectory . '" && ' . $script;
 
-        $output->writeln("Executing <info>$script</info>");
+        $this->logger->notice('Executing {script}', ['script' => $script]);
 
         try {
             $this->commandRunner->run($script);

--- a/src/Module/Template/Step/AddPageListToLayoutVariables.php
+++ b/src/Module/Template/Step/AddPageListToLayoutVariables.php
@@ -5,16 +5,15 @@ namespace Couscous\Module\Template\Step;
 use Couscous\Module\Template\Model\HtmlFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Add to the layout variables the list of the pages of the website.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class AddPageListToLayoutVariables implements \Couscous\Step
+class AddPageListToLayoutVariables implements Step
 {
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         /** @var HtmlFile[] $htmlFiles */
         $htmlFiles = $repository->findFilesByType('Couscous\Module\Template\Model\HtmlFile');

--- a/src/Module/Template/Step/LoadAssets.php
+++ b/src/Module/Template/Step/LoadAssets.php
@@ -5,7 +5,6 @@ namespace Couscous\Module\Template\Step;
 use Couscous\Model\LazyFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -17,7 +16,7 @@ use Symfony\Component\Finder\SplFileInfo;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class LoadAssets implements \Couscous\Step
+class LoadAssets implements Step
 {
     /**
      * @var Filesystem
@@ -29,7 +28,7 @@ class LoadAssets implements \Couscous\Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         if (! $repository->metadata['template.directory']) {
             return;

--- a/src/Module/Template/Step/ProcessTwigLayouts.php
+++ b/src/Module/Template/Step/ProcessTwigLayouts.php
@@ -5,7 +5,6 @@ namespace Couscous\Module\Template\Step;
 use Couscous\Module\Template\Model\HtmlFile;
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Twig_Environment;
@@ -16,11 +15,11 @@ use Twig_Loader_Array;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ProcessTwigLayouts implements \Couscous\Step
+class ProcessTwigLayouts implements Step
 {
     const DEFAULT_LAYOUT_NAME = 'default.twig';
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         if (! $repository->metadata['template.directory']) {
             return;

--- a/src/Module/Template/Step/UseDefaultTemplate.php
+++ b/src/Module/Template/Step/UseDefaultTemplate.php
@@ -4,7 +4,6 @@ namespace Couscous\Module\Template\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -12,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class UseDefaultTemplate implements \Couscous\Step
+class UseDefaultTemplate implements Step
 {
     const DEFAULT_TEMPLATE_URL = 'https://github.com/CouscousPHP/Template-Light.git';
 
@@ -26,7 +25,7 @@ class UseDefaultTemplate implements \Couscous\Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         if ($this->useRemoteTemplate($repository)
             || $this->hasCustomTemplateDirectory($repository)

--- a/src/Module/Template/Step/ValidateTemplateDirectory.php
+++ b/src/Module/Template/Step/ValidateTemplateDirectory.php
@@ -4,7 +4,6 @@ namespace Couscous\Module\Template\Step;
 
 use Couscous\Model\Repository;
 use Couscous\Step;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -12,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class ValidateTemplateDirectory implements \Couscous\Step
+class ValidateTemplateDirectory implements Step
 {
     const DEFAULT_TEMPLATE_DIRECTORY = 'website';
 
@@ -26,7 +25,7 @@ class ValidateTemplateDirectory implements \Couscous\Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository, OutputInterface $output)
+    public function __invoke(Repository $repository)
     {
         $directory = $repository->metadata['template.directory'];
 

--- a/src/Step.php
+++ b/src/Step.php
@@ -3,7 +3,6 @@
 namespace Couscous;
 
 use Couscous\Model\Repository;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Generation step.
@@ -15,8 +14,7 @@ interface Step
     /**
      * Process the given repository.
      *
-     * @param Repository      $repository
-     * @param OutputInterface $output     Output for the user.
+     * @param Repository $repository
      */
-    public function __invoke(Repository $repository, OutputInterface $output);
+    public function __invoke(Repository $repository);
 }

--- a/tests/UnitTest/GeneratorTest.php
+++ b/tests/UnitTest/GeneratorTest.php
@@ -6,7 +6,6 @@ use Couscous\Generator;
 use Couscous\Model\Repository;
 use Couscous\Tests\UnitTest\Mock\MockRepository;
 use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -21,17 +20,16 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $filesystem = $this->createFileSystem();
         $repository = new MockRepository();
-        $output = new NullOutput();
 
         $steps = [
-            $this->createStep($repository, $output),
-            $this->createStep($repository, $output),
-            $this->createStep($repository, $output),
+            $this->createStep($repository),
+            $this->createStep($repository),
+            $this->createStep($repository),
         ];
 
         $generator = new Generator($filesystem, $steps);
 
-        $generator->generate($repository, $output);
+        $generator->generate($repository, new NullOutput());
     }
 
     /**
@@ -42,13 +40,13 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Component\Filesystem\Filesystem');
     }
 
-    private function createStep(Repository $repository, OutputInterface $output)
+    private function createStep(Repository $repository)
     {
         $step = $this->getMockForAbstractClass('Couscous\Step');
 
         $step->expects($this->once())
             ->method('__invoke')
-            ->with($repository, $output);
+            ->with($repository);
 
         return $step;
     }

--- a/tests/UnitTest/Module/Config/Step/OverrideBaseUrlForPreviewTest.php
+++ b/tests/UnitTest/Module/Config/Step/OverrideBaseUrlForPreviewTest.php
@@ -4,7 +4,6 @@ namespace Couscous\Tests\UnitTest\Module\Config\Step;
 
 use Couscous\Module\Config\Step\OverrideBaseUrlForPreview;
 use Couscous\Tests\UnitTest\Mock\MockRepository;
-use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * @covers \Couscous\Module\Config\Step\OverrideBaseUrlForPreview
@@ -21,7 +20,7 @@ class OverrideBaseUrlForPreviewTest extends \PHPUnit_Framework_TestCase
         $repository->metadata['preview'] = true;
 
         $step = new OverrideBaseUrlForPreview();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals('', $repository->metadata['baseUrl']);
     }
@@ -36,7 +35,7 @@ class OverrideBaseUrlForPreviewTest extends \PHPUnit_Framework_TestCase
         $repository->metadata['preview'] = false;
 
         $step = new OverrideBaseUrlForPreview();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals('foo', $repository->metadata['baseUrl']);
     }

--- a/tests/UnitTest/Module/Config/Step/SetDefaultConfigTest.php
+++ b/tests/UnitTest/Module/Config/Step/SetDefaultConfigTest.php
@@ -4,7 +4,6 @@ namespace Couscous\Tests\UnitTest\Module\Config\Step;
 
 use Couscous\Module\Config\Step\SetDefaultConfig;
 use Couscous\Tests\UnitTest\Mock\MockRepository;
-use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * @covers \Couscous\Module\Config\Step\SetDefaultConfig
@@ -19,7 +18,7 @@ class SetDefaultConfigTest extends \PHPUnit_Framework_TestCase
         $repository = new MockRepository();
 
         $step = new SetDefaultConfig();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals(['vendor', 'website'], $repository->metadata['exclude']);
     }

--- a/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
@@ -6,7 +6,6 @@ use Couscous\Model\LazyFile;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Repository;
 use Couscous\Module\Markdown\Step\ProcessMarkdownFileName;
-use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * @covers \Couscous\Module\Markdown\Step\ProcessMarkdownFileName
@@ -35,7 +34,7 @@ class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
         $repository->addFile($file);
 
         $step = new ProcessMarkdownFileName();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $files = $repository->getFiles();
 
@@ -54,7 +53,7 @@ class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
         $repository->addFile($file);
 
         $step = new ProcessMarkdownFileName();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $files = $repository->getFiles();
 

--- a/tests/UnitTest/Module/Markdown/Step/RewriteMarkdownLinksTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/RewriteMarkdownLinksTest.php
@@ -5,7 +5,6 @@ namespace Couscous\Tests\UnitTest\Module\Markdown\Step;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Repository;
 use Couscous\Module\Markdown\Step\RewriteMarkdownLinks;
-use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * @covers \Couscous\Module\Markdown\Step\RewriteMarkdownLinks
@@ -31,7 +30,7 @@ MARKDOWN;
         $repository->addFile($file);
 
         $step = new RewriteMarkdownLinks();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals($expected, $file->content);
     }

--- a/tests/UnitTest/Module/Template/Step/AddPageListToTemplateVariablesTest.php
+++ b/tests/UnitTest/Module/Template/Step/AddPageListToTemplateVariablesTest.php
@@ -6,7 +6,6 @@ use Couscous\Module\Template\Model\HtmlFile;
 use Couscous\Model\Repository;
 use Couscous\Module\Template\Step\AddPageListToLayoutVariables;
 use Couscous\Tests\UnitTest\Mock\MockRepository;
-use Symfony\Component\Console\Output\NullOutput;
 
 /**
  * @covers \Couscous\Module\Template\Step\AddPageListToLayoutVariables
@@ -78,6 +77,6 @@ class AddPageListToTemplateVariablesTest extends \PHPUnit_Framework_TestCase
         }
 
         $step = new AddPageListToLayoutVariables();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
     }
 }

--- a/tests/UnitTest/Module/Template/Step/FetchRemoteTemplateTest.php
+++ b/tests/UnitTest/Module/Template/Step/FetchRemoteTemplateTest.php
@@ -4,7 +4,7 @@ namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\FetchRemoteTemplate;
 use Couscous\Tests\UnitTest\Mock\MockRepository;
-use Symfony\Component\Console\Output\NullOutput;
+use Psr\Log\NullLogger;
 
 /**
  * @covers \Couscous\Module\Template\Step\FetchRemoteTemplate
@@ -19,14 +19,14 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
         $commandRunner = $this->getMock('Couscous\CommandRunner\CommandRunner');
 
-        $step = new FetchRemoteTemplate($filesystem, $commandRunner);
+        $step = new FetchRemoteTemplate($filesystem, $commandRunner, new NullLogger());
 
         $repository = new MockRepository();
 
         $commandRunner->expects($this->never())
             ->method('run');
 
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertNull($repository->metadata['template.directory']);
     }
@@ -39,7 +39,7 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
         $commandRunner = $this->getMock('Couscous\CommandRunner\CommandRunner');
 
-        $step = new FetchRemoteTemplate($filesystem, $commandRunner);
+        $step = new FetchRemoteTemplate($filesystem, $commandRunner, new NullLogger());
 
         $repository = new MockRepository();
         $repository->metadata['template.url'] = 'git://foo';
@@ -48,7 +48,7 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
             ->method('run')
             ->with($this->matches('git clone git://foo %s'));
 
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertNotNull($repository->metadata['template.directory']);
     }
@@ -61,7 +61,7 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
         $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
         $commandRunner = $this->getMock('Couscous\CommandRunner\CommandRunner');
 
-        $step = new FetchRemoteTemplate($filesystem, $commandRunner);
+        $step = new FetchRemoteTemplate($filesystem, $commandRunner, new NullLogger());
 
         $commandRunner->expects($this->once())
             ->method('run')
@@ -70,14 +70,14 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
         // Calling once
         $repository = new MockRepository();
         $repository->metadata['template.url'] = 'git://foo';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
         $this->assertNotNull($repository->metadata['template.directory']);
 
         // Calling twice
         $repository = new MockRepository();
         $repository->regenerate = true;
         $repository->metadata['template.url'] = 'git://foo';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
         $this->assertNotNull($repository->metadata['template.directory']);
     }
 }

--- a/tests/UnitTest/Module/Template/Step/UseDefaultTemplateTest.php
+++ b/tests/UnitTest/Module/Template/Step/UseDefaultTemplateTest.php
@@ -4,7 +4,6 @@ namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\UseDefaultTemplate;
 use Couscous\Tests\UnitTest\Mock\MockRepository;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -20,7 +19,7 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
         $step = new UseDefaultTemplate($this->createFilesystem());
 
         $repository = new MockRepository();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals(UseDefaultTemplate::DEFAULT_TEMPLATE_URL, $repository->metadata['template.url']);
     }
@@ -33,7 +32,7 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
         $step = new UseDefaultTemplate($this->createFilesystem(true));
 
         $repository = new MockRepository();
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertNull($repository->metadata['template.url']);
     }
@@ -48,7 +47,7 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
         $repository = new MockRepository();
         $repository->metadata['template.directory'] = 'foo';
 
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertNull($repository->metadata['template.url']);
     }
@@ -63,7 +62,7 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
         $repository = new MockRepository();
         $repository->metadata['template.url'] = 'foo';
 
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         // Assert URL isn't overridden
         $this->assertEquals('foo', $repository->metadata['template.url']);

--- a/tests/UnitTest/Module/Template/Step/ValidateTemplateDirectoryTest.php
+++ b/tests/UnitTest/Module/Template/Step/ValidateTemplateDirectoryTest.php
@@ -4,7 +4,6 @@ namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\ValidateTemplateDirectory;
 use Couscous\Tests\UnitTest\Mock\MockRepository;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -20,7 +19,7 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
         $step = new ValidateTemplateDirectory($this->createFilesystem());
         $repository = new MockRepository();
         $repository->sourceDirectory = '/foo';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals('/foo/website', $repository->metadata['template.directory']);
     }
@@ -34,7 +33,7 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
         $repository = new MockRepository();
         $repository->sourceDirectory = '/foo';
         $repository->metadata['template.directory'] = 'bar';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals('/foo/bar', $repository->metadata['template.directory']);
     }
@@ -48,7 +47,7 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
         $repository = new MockRepository();
         $repository->sourceDirectory = '/foo';
         $repository->metadata['template.directory'] = '/hello/world';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
 
         $this->assertEquals('/hello/world', $repository->metadata['template.directory']);
     }
@@ -64,7 +63,7 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
         $repository = new MockRepository();
         $repository->sourceDirectory = '/foo';
         $repository->metadata['template.directory'] = 'bar';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
     }
 
     /**
@@ -78,7 +77,7 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
         $repository = new MockRepository();
         $repository->sourceDirectory = '/foo';
         $repository->metadata['template.directory'] = '/hello/world';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
     }
 
     /**
@@ -91,7 +90,7 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
         $step = new ValidateTemplateDirectory($this->createFilesystem(false));
         $repository = new MockRepository();
         $repository->sourceDirectory = '/foo';
-        $step->__invoke($repository, new NullOutput());
+        $step->__invoke($repository);
     }
 
     /**


### PR DESCRIPTION
Current `StepInterface`:

```php
interface Step
{
    public function __invoke(Repository $repository, OutputInterface $output);
}
```

This was stupid of me to do this initially: a step shouldn't be coupled to the CLI. If a step wants to log messages, it just needs a logger.

Now:

```php
interface Step
{
    public function __invoke(Repository $repository);
}
```

Steps can use dependency injection to inject an instance of `Psr\Log\LoggerInterface`. The implementation logs messages to the `OutputInterface` like before.

Example here: [LoadConfig.php](https://github.com/CouscousPHP/Couscous/blob/feature/logger/src/Module/Config/Step/LoadConfig.php)

Review and comments welcome.