### PR TITLE
Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ Couscous was designed to be as simple as possible. By embracing simplicity, it b
 
 ### Website generation
 
-The website generation is composed of a list of **steps** to process the `Repository` model object:
+The website generation is composed of a list of **steps** to process the `Project` model object:
 
 ```php
 interface Step
 {
     /**
-     * Process the given repository.
+     * Process the given project.
      *
-     * @param Repository $repository
+     * @param Project $project
      */
-    public function __invoke(Repository $repository);
+    public function __invoke(Project $project);
 }
 ```
 
@@ -48,10 +48,10 @@ For example, here is a step that would preprocess Markdown files to put the word
 ```php
 class PutCouscousInBold implements \Couscous\Step
 {
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         /** @var MarkdownFile[] $markdownFiles */
-        $markdownFiles = $repository->findFilesByType('Couscous\Model\MarkdownFile');
+        $markdownFiles = $project->findFilesByType('Couscous\Model\MarkdownFile');
 
         foreach ($markdownFiles as $file) {
             $file->content = str_replace('Couscous', '**Couscous**', $file->content);

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "erusev/parsedown-extra": "~0.2.0",
         "phine/phar": "~1.0",
         "mnapoli/front-yaml": "~1.0",
-        "mnapoli/php-di": "~4.4",
+        "mnapoli/php-di": "5.0.x-dev@dev",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/Application/Cli/DeployCommand.php
+++ b/src/Application/Cli/DeployCommand.php
@@ -3,7 +3,7 @@
 namespace Couscous\Application\Cli;
 
 use Couscous\Generator;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Deployer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -75,14 +75,14 @@ class DeployCommand extends Command
         $repositoryUrl   = trim(shell_exec('git config --get remote.origin.url'));
         $targetBranch    = $input->getOption('branch');
 
-        $repository = new Repository($sourceDirectory, getcwd() . '/.couscous/generated');
+        $project = new Project($sourceDirectory, getcwd() . '/.couscous/generated');
 
         // Generate the website
-        $this->generator->generate($repository, $output);
+        $this->generator->generate($project, $output);
 
         $output->writeln('');
 
         // Deploy it
-        $this->deployer->deploy($repository, $output, $repositoryUrl, $targetBranch);
+        $this->deployer->deploy($project, $output, $repositoryUrl, $targetBranch);
     }
 }

--- a/src/Application/Cli/GenerateCommand.php
+++ b/src/Application/Cli/GenerateCommand.php
@@ -3,7 +3,7 @@
 namespace Couscous\Application\Cli;
 
 use Couscous\Generator;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -51,8 +51,8 @@ class GenerateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $repository = new Repository($input->getArgument('source'), $input->getOption('target'));
+        $project = new Project($input->getArgument('source'), $input->getOption('target'));
 
-        $this->generator->generate($repository, $output);
+        $this->generator->generate($project, $output);
     }
 }

--- a/src/Application/Cli/PreviewCommand.php
+++ b/src/Application/Cli/PreviewCommand.php
@@ -3,7 +3,7 @@
 namespace Couscous\Application\Cli;
 
 use Couscous\Generator;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -99,15 +99,15 @@ class PreviewCommand extends Command
         $targetDirectory,
         $regenerate = false
     ) {
-        $repository = new Repository($sourceDirectory, $targetDirectory);
+        $project = new Project($sourceDirectory, $targetDirectory);
 
-        $repository->metadata['preview'] = true;
+        $project->metadata['preview'] = true;
 
-        $repository->regenerate = $regenerate;
+        $project->regenerate = $regenerate;
 
-        $this->generator->generate($repository, $output);
+        $this->generator->generate($project, $output);
 
-        return $repository->watchlist;
+        return $project->watchlist;
     }
 
     private function startWebServer(InputInterface $input, OutputInterface $output, $targetDirectory)

--- a/src/Application/ContainerFactory.php
+++ b/src/Application/ContainerFactory.php
@@ -19,6 +19,12 @@ class ContainerFactory
 
         $builder->addDefinitions(__DIR__ . '/config.php');
 
+        $moduleConfigs = glob(__DIR__ . '/../Module/*/config.php');
+
+        foreach ($moduleConfigs as $moduleConfig) {
+            $builder->addDefinitions($moduleConfig);
+        }
+
         return $builder->build();
     }
 }

--- a/src/Application/config.php
+++ b/src/Application/config.php
@@ -7,36 +7,30 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 return [
 
-    'steps' => [
-        'Couscous\Module\Core\Step\ClearTargetDirectory',
-        'Couscous\Module\Config\Step\SetDefaultConfig',
-        'Couscous\Module\Config\Step\LoadConfig',
-        'Couscous\Module\Config\Step\OverrideBaseUrlForPreview',
-        'Couscous\Module\Scripts\Step\ExecuteBeforeScripts',
-        'Couscous\Module\Template\Step\UseDefaultTemplate',
-        'Couscous\Module\Template\Step\FetchRemoteTemplate',
-        'Couscous\Module\Template\Step\ValidateTemplateDirectory',
-        'Couscous\Module\Bower\Step\RunBowerInstall',
-        'Couscous\Module\Template\Step\LoadAssets',
-        'Couscous\Module\Markdown\Step\LoadMarkdownFiles',
-        'Couscous\Module\Markdown\Step\ParseMarkdownFrontMatter',
-        'Couscous\Module\Markdown\Step\ProcessMarkdownFileName',
-        'Couscous\Module\Markdown\Step\RewriteMarkdownLinks',
-        'Couscous\Module\Markdown\Step\RenderMarkdown',
-        'Couscous\Module\Template\Step\AddPageListToLayoutVariables',
-        'Couscous\Module\Template\Step\ProcessTwigLayouts',
-        'Couscous\Module\Core\Step\WriteFiles',
-        'Couscous\Module\Scripts\Step\ExecuteAfterScripts',
+    // Generation steps are added by modules
+    'steps.init' => [
+    ],
+    'steps.before' => [
+    ],
+    'steps.preprocessing' => [
+    ],
+    'steps.postprocessing' => [
+    ],
+    'steps.after' => [
     ],
 
-    'Couscous\Generator' => DI\object()
-        ->constructorParameter('steps', DI\link('steps.instances')),
-
-    'steps.instances' => DI\factory(function (ContainerInterface $c) {
-        return array_map(function ($class) use ($c) {
-            return $c->get($class);
-        }, $c->get('steps'));
+    'steps' => DI\factory(function (ContainerInterface $c) {
+        return array_merge(
+            $c->get('steps.init'),
+            $c->get('steps.before'),
+            $c->get('steps.preprocessing'),
+            $c->get('steps.postprocessing'),
+            $c->get('steps.after')
+        );
     }),
+
+    'Couscous\Generator' => DI\object()
+        ->constructorParameter('steps', DI\link('steps')),
 
     'application' => DI\factory(function (ContainerInterface $c) {
         $application = new Application('Couscous');
@@ -48,11 +42,6 @@ return [
 
         return $application;
     }),
-
-    'Mni\FrontYAML\Parser' => DI\object()
-        ->constructorParameter('markdownParser', DI\link('Mni\FrontYAML\Markdown\MarkdownParser')),
-    'Mni\FrontYAML\Markdown\MarkdownParser' => DI\object('Mni\FrontYAML\Bridge\Parsedown\ParsedownParser')
-        ->constructor(DI\link('ParsedownExtra')),
 
     'Symfony\Component\Console\Logger\ConsoleLogger' => DI\object()
         ->constructorParameter('verbosityLevelMap', [

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -4,7 +4,7 @@ namespace Couscous;
 
 use Couscous\CommandRunner\CommandException;
 use Couscous\CommandRunner\CommandRunner;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -33,16 +33,16 @@ class Deployer
     }
 
     /**
-     * @param Repository      $repository
+     * @param Project         $project
      * @param OutputInterface $output
      * @param string          $repositoryUrl Repository in which to deploy the files.
      * @param string          $branch        Git branch in which to deploy the files.
      */
-    public function deploy(Repository $repository, OutputInterface $output, $repositoryUrl, $branch)
+    public function deploy(Project $project, OutputInterface $output, $repositoryUrl, $branch)
     {
         $output->writeln("<comment>Deploying the website</comment>");
 
-        $directory    = $repository->targetDirectory;
+        $directory    = $project->targetDirectory;
         $tmpDirectory = $this->createTempDirectory();
 
         $this->cloneRepository($output, $repositoryUrl, $tmpDirectory);

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -2,7 +2,7 @@
 
 namespace Couscous;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -33,18 +33,18 @@ class Generator
         $this->steps      = $steps;
     }
 
-    public function generate(Repository $repository, OutputInterface $output)
+    public function generate(Project $project, OutputInterface $output)
     {
         $output->writeln(sprintf(
             "<comment>Generating %s to %s</comment>",
-            $repository->sourceDirectory,
-            $repository->targetDirectory
+            $project->sourceDirectory,
+            $project->targetDirectory
         ));
 
-        $this->filesystem->mkdir($repository->targetDirectory);
+        $this->filesystem->mkdir($project->targetDirectory);
 
         foreach ($this->steps as $step) {
-            $step->__invoke($repository, $output);
+            $step->__invoke($project, $output);
         }
     }
 }

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -3,7 +3,7 @@
 namespace Couscous\Model;
 
 /**
- * Represents a file of the repository.
+ * Represents a file of the project.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */

--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -6,14 +6,11 @@ use Couscous\Model\WatchList\WatchList;
 use Symfony\Component\Finder\Finder;
 
 /**
- * Repository containing files.
- *
- * Extends stdClass so that properties can be added by processors at will.
- * TODO should not extend stdClass anymore! It has been replaced by the metadata property...
+ * Project containing files.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class Repository extends \stdClass
+class Project
 {
     /**
      * Directory containing the sources files to process.

--- a/src/Module/Bower/Step/RunBowerInstall.php
+++ b/src/Module/Bower/Step/RunBowerInstall.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Bower\Step;
 
 use Couscous\CommandRunner\CommandRunner;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -40,9 +40,9 @@ class RunBowerInstall implements Step
         $this->logger = $logger;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        if ($repository->regenerate || ! $this->hasBowerJson($repository)) {
+        if ($project->regenerate || ! $this->hasBowerJson($project)) {
             return;
         }
 
@@ -50,7 +50,7 @@ class RunBowerInstall implements Step
 
         $result = $this->commandRunner->run(sprintf(
             'cd "%s" && bower install',
-            $repository->metadata['template.directory']
+            $project->metadata['template.directory']
         ));
 
         if ($result) {
@@ -58,13 +58,13 @@ class RunBowerInstall implements Step
         }
     }
 
-    private function hasBowerJson(Repository $repository)
+    private function hasBowerJson(Project $project)
     {
-        if (! $repository->metadata['template.directory']) {
+        if (! $project->metadata['template.directory']) {
             return false;
         }
 
-        $filename = $repository->metadata['template.directory'] . '/bower.json';
+        $filename = $project->metadata['template.directory'] . '/bower.json';
 
         return $this->filesystem->exists($filename);
     }

--- a/src/Module/Bower/config.php
+++ b/src/Module/Bower/config.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+
+    'steps.preprocessing' => DI\add([
+        DI\link('Couscous\Module\Bower\Step\RunBowerInstall'),
+    ]),
+
+];

--- a/src/Module/Config/Step/LoadConfig.php
+++ b/src/Module/Config/Step/LoadConfig.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Config\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -10,7 +10,7 @@ use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 
 /**
- * Loads the Couscous config for the repository.
+ * Loads the Couscous config for the project.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
@@ -40,9 +40,9 @@ class LoadConfig implements Step
         $this->logger     = $logger;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        $filename = $repository->sourceDirectory . '/' . self::FILENAME;
+        $filename = $project->sourceDirectory . '/' . self::FILENAME;
 
         if (! $this->filesystem->exists($filename)) {
             $this->logger->notice('No couscous.yml configuration file found, using default config');
@@ -52,8 +52,8 @@ class LoadConfig implements Step
         $metadata = $this->parseYamlFile($filename);
         $metadata = $this->validateConfig($metadata);
 
-        $repository->metadata->setMany($metadata);
-        $repository->watchlist->watchFile($filename);
+        $project->metadata->setMany($metadata);
+        $project->watchlist->watchFile($filename);
     }
 
     private function parseYamlFile($filename)

--- a/src/Module/Config/Step/OverrideBaseUrlForPreview.php
+++ b/src/Module/Config/Step/OverrideBaseUrlForPreview.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Config\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 
 /**
  * Override the baseUrl if we are in preview.
@@ -11,10 +11,10 @@ use Couscous\Model\Repository;
  */
 class OverrideBaseUrlForPreview implements \Couscous\Step
 {
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        if ($repository->metadata['preview'] === true) {
-            $repository->metadata['baseUrl'] = '';
+        if ($project->metadata['preview'] === true) {
+            $project->metadata['baseUrl'] = '';
         }
     }
 }

--- a/src/Module/Config/Step/SetDefaultConfig.php
+++ b/src/Module/Config/Step/SetDefaultConfig.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Config\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 
 /**
@@ -18,8 +18,8 @@ class SetDefaultConfig implements Step
         ],
     ];
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        $repository->metadata->setMany($this->defaultConfig);
+        $project->metadata->setMany($this->defaultConfig);
     }
 }

--- a/src/Module/Config/config.php
+++ b/src/Module/Config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+
+    'steps.init' => DI\add([
+        DI\link('Couscous\Module\Config\Step\SetDefaultConfig'),
+        DI\link('Couscous\Module\Config\Step\LoadConfig'),
+        DI\link('Couscous\Module\Config\Step\OverrideBaseUrlForPreview'),
+    ]),
+
+];

--- a/src/Module/Core/Step/ClearTargetDirectory.php
+++ b/src/Module/Core/Step/ClearTargetDirectory.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Core\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -24,10 +24,10 @@ class ClearTargetDirectory implements Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         $files = new Finder();
-        $files->in($repository->targetDirectory);
+        $files->in($project->targetDirectory);
 
         $this->filesystem->remove($files);
     }

--- a/src/Module/Core/Step/WriteFiles.php
+++ b/src/Module/Core/Step/WriteFiles.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Core\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -30,10 +30,10 @@ class WriteFiles implements Step
         $this->logger     = $logger;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        foreach ($repository->getFiles() as $file) {
-            $targetFilename = $repository->targetDirectory . '/' . $file->relativeFilename;
+        foreach ($project->getFiles() as $file) {
+            $targetFilename = $project->targetDirectory . '/' . $file->relativeFilename;
 
             if ($this->filesystem->exists($targetFilename)) {
                 $this->logger->info(

--- a/src/Module/Core/config.php
+++ b/src/Module/Core/config.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+
+    'steps.after' => DI\add([
+        DI\link('Couscous\Module\Core\Step\ClearTargetDirectory'),
+        DI\link('Couscous\Module\Core\Step\WriteFiles'),
+    ]),
+
+];

--- a/src/Module/Markdown/Step/LoadMarkdownFiles.php
+++ b/src/Module/Markdown/Step/LoadMarkdownFiles.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Markdown\Step;
 
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -14,18 +14,18 @@ use Symfony\Component\Finder\SplFileInfo;
  */
 class LoadMarkdownFiles implements Step
 {
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        $files = $repository->sourceFiles();
+        $files = $project->sourceFiles();
         $files->name('*.md');
 
         foreach ($files as $file) {
             /** @var SplFileInfo $file */
             $content = file_get_contents($file->getPathname());
 
-            $repository->addFile(new MarkdownFile($file->getRelativePathname(), $content));
+            $project->addFile(new MarkdownFile($file->getRelativePathname(), $content));
         }
 
-        $repository->watchlist->watchFiles($files);
+        $project->watchlist->watchFiles($files);
     }
 }

--- a/src/Module/Markdown/Step/ParseMarkdownFrontMatter.php
+++ b/src/Module/Markdown/Step/ParseMarkdownFrontMatter.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Markdown\Step;
 
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Mni\FrontYAML\Parser;
 
@@ -24,10 +24,10 @@ class ParseMarkdownFrontMatter implements Step
         $this->markdownParser = $markdownParser;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         /** @var MarkdownFile[] $markdownFiles */
-        $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
+        $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
 
         foreach ($markdownFiles as $file) {
             $document = $this->markdownParser->parse($file->getContent());

--- a/src/Module/Markdown/Step/ProcessMarkdownFileName.php
+++ b/src/Module/Markdown/Step/ProcessMarkdownFileName.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Markdown\Step;
 
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 
 /**
@@ -13,18 +13,18 @@ use Couscous\Step;
  */
 class ProcessMarkdownFileName implements Step
 {
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         /** @var MarkdownFile[] $markdownFiles */
-        $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
+        $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
 
         foreach ($markdownFiles as $markdownFile) {
-            $repository->removeFile($markdownFile);
+            $project->removeFile($markdownFile);
 
             $this->renameFileExtension($markdownFile);
             $this->renameReadme($markdownFile);
 
-            $repository->addFile($markdownFile);
+            $project->addFile($markdownFile);
         }
     }
 

--- a/src/Module/Markdown/Step/RenderMarkdown.php
+++ b/src/Module/Markdown/Step/RenderMarkdown.php
@@ -4,7 +4,7 @@ namespace Couscous\Module\Markdown\Step;
 
 use Couscous\Module\Template\Model\HtmlFile;
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Mni\FrontYAML\Parser;
 
@@ -25,15 +25,15 @@ class RenderMarkdown implements Step
         $this->markdownParser = $markdownParser;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         /** @var MarkdownFile[] $markdownFiles */
-        $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
+        $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
 
         foreach ($markdownFiles as $markdownFile) {
             $htmlFile = $this->renderFile($markdownFile);
 
-            $repository->replaceFile($markdownFile, $htmlFile);
+            $project->replaceFile($markdownFile, $htmlFile);
         }
     }
 

--- a/src/Module/Markdown/Step/RewriteMarkdownLinks.php
+++ b/src/Module/Markdown/Step/RewriteMarkdownLinks.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Markdown\Step;
 
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 
 /**
@@ -17,10 +17,10 @@ class RewriteMarkdownLinks implements Step
     const MARKDOWN_LINK_REGEX = '#\[([^\]]+)\]\(([^\)]+)\.md\)#';
     const REGEX_REPLACEMENT   = '[$1]($2.html)';
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         /** @var MarkdownFile[] $markdownFiles */
-        $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
+        $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
 
         foreach ($markdownFiles as $file) {
             $file->content = preg_replace(

--- a/src/Module/Markdown/config.php
+++ b/src/Module/Markdown/config.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    'steps.preprocessing' => DI\add([
+        DI\link('Couscous\Module\Markdown\Step\LoadMarkdownFiles'),
+        DI\link('Couscous\Module\Markdown\Step\ParseMarkdownFrontMatter'),
+        DI\link('Couscous\Module\Markdown\Step\ProcessMarkdownFileName'),
+        DI\link('Couscous\Module\Markdown\Step\RewriteMarkdownLinks'),
+        DI\link('Couscous\Module\Markdown\Step\RenderMarkdown'),
+    ]),
+
+    'Mni\FrontYAML\Parser' => DI\object()
+        ->constructorParameter('markdownParser', DI\link('Mni\FrontYAML\Markdown\MarkdownParser')),
+
+    'Mni\FrontYAML\Markdown\MarkdownParser' => DI\object('Mni\FrontYAML\Bridge\Parsedown\ParsedownParser')
+        ->constructor(DI\link('ParsedownExtra')),
+
+];

--- a/src/Module/Scripts/Step/ExecuteAfterScripts.php
+++ b/src/Module/Scripts/Step/ExecuteAfterScripts.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Scripts\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 
 /**
@@ -12,10 +12,10 @@ use Couscous\Step;
  */
 class ExecuteAfterScripts extends ExecuteScripts implements Step
 {
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        $scripts = $repository->metadata['scripts.after'];
+        $scripts = $project->metadata['scripts.after'];
 
-        $this->executeScripts($scripts, $repository);
+        $this->executeScripts($scripts, $project);
     }
 }

--- a/src/Module/Scripts/Step/ExecuteBeforeScripts.php
+++ b/src/Module/Scripts/Step/ExecuteBeforeScripts.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Scripts\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 
 /**
@@ -12,10 +12,10 @@ use Couscous\Step;
  */
 class ExecuteBeforeScripts extends ExecuteScripts implements Step
 {
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        $scripts = $repository->metadata['scripts.before'];
+        $scripts = $project->metadata['scripts.before'];
 
-        $this->executeScripts($scripts, $repository);
+        $this->executeScripts($scripts, $project);
     }
 }

--- a/src/Module/Scripts/Step/ExecuteScripts.php
+++ b/src/Module/Scripts/Step/ExecuteScripts.php
@@ -4,7 +4,7 @@ namespace Couscous\Module\Scripts\Step;
 
 use Couscous\CommandRunner\CommandException;
 use Couscous\CommandRunner\CommandRunner;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -30,14 +30,14 @@ abstract class ExecuteScripts
         $this->logger        = $logger;
     }
 
-    protected function executeScripts($scripts, Repository $repository)
+    protected function executeScripts($scripts, Project $project)
     {
         if (empty($scripts)) {
             return;
         }
 
         foreach ($scripts as $script) {
-            $this->executeScript($repository->sourceDirectory, $script);
+            $this->executeScript($project->sourceDirectory, $script);
         }
     }
 

--- a/src/Module/Scripts/config.php
+++ b/src/Module/Scripts/config.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+
+    'steps.before' => DI\add([
+        DI\link('Couscous\Module\Scripts\Step\ExecuteBeforeScripts'),
+    ]),
+    'steps.after' => DI\add([
+        DI\link('Couscous\Module\Scripts\Step\ExecuteAfterScripts'),
+    ]),
+
+];

--- a/src/Module/Template/Step/AddPageListToLayoutVariables.php
+++ b/src/Module/Template/Step/AddPageListToLayoutVariables.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Template\Step;
 
 use Couscous\Module\Template\Model\HtmlFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 
 /**
@@ -13,10 +13,10 @@ use Couscous\Step;
  */
 class AddPageListToLayoutVariables implements Step
 {
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         /** @var HtmlFile[] $htmlFiles */
-        $htmlFiles = $repository->findFilesByType('Couscous\Module\Template\Model\HtmlFile');
+        $htmlFiles = $project->findFilesByType('Couscous\Module\Template\Model\HtmlFile');
 
         $pageList = [];
         $pageTree = [];
@@ -40,8 +40,8 @@ class AddPageListToLayoutVariables implements Step
         natsort($pageList);
         $this->sortRecursively($pageTree);
 
-        $repository->metadata['pageList'] = $pageList;
-        $repository->metadata['pageTree'] = $pageTree;
+        $project->metadata['pageList'] = $pageList;
+        $project->metadata['pageTree'] = $pageTree;
     }
 
     private function setValue(array &$array, array $path, $value)

--- a/src/Module/Template/Step/FetchRemoteTemplate.php
+++ b/src/Module/Template/Step/FetchRemoteTemplate.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Template\Step;
 
 use Couscous\CommandRunner\CommandRunner;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -51,16 +51,16 @@ class FetchRemoteTemplate implements Step
         $this->logger        = $logger;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
         // In preview we avoid cloning the repository every time
-        if ($repository->regenerate && $this->templateDirectory) {
-            $repository->metadata['template.directory'] = $this->templateDirectory;
+        if ($project->regenerate && $this->templateDirectory) {
+            $project->metadata['template.directory'] = $this->templateDirectory;
 
             return;
         }
 
-        $templateUrl = $repository->metadata['template.url'];
+        $templateUrl = $project->metadata['template.url'];
 
         if ($templateUrl === null) {
             return;
@@ -69,7 +69,7 @@ class FetchRemoteTemplate implements Step
         $directory = $this->fetchGitTemplate($templateUrl);
 
         $this->templateDirectory = $directory;
-        $repository->metadata['template.directory'] = $directory;
+        $project->metadata['template.directory'] = $directory;
     }
 
     private function fetchGitTemplate($gitUrl)

--- a/src/Module/Template/Step/LoadAssets.php
+++ b/src/Module/Template/Step/LoadAssets.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Template\Step;
 
 use Couscous\Model\LazyFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -28,23 +28,23 @@ class LoadAssets implements Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        if (! $repository->metadata['template.directory']) {
+        if (! $project->metadata['template.directory']) {
             return;
         }
 
         $files = new Finder();
         $files->files()
-            ->in($repository->metadata['template.directory'])
+            ->in($project->metadata['template.directory'])
             ->ignoreDotFiles(true)
             ->notName('*.twig');
 
-        $repository->watchlist->watchFiles($files);
+        $project->watchlist->watchFiles($files);
 
         foreach ($files as $file) {
             /** @var SplFileInfo $file */
-            $repository->addFile(new LazyFile($file->getPathname(), $file->getRelativePathname()));
+            $project->addFile(new LazyFile($file->getPathname(), $file->getRelativePathname()));
         }
     }
 }

--- a/src/Module/Template/Step/ProcessTwigLayouts.php
+++ b/src/Module/Template/Step/ProcessTwigLayouts.php
@@ -3,7 +3,7 @@
 namespace Couscous\Module\Template\Step;
 
 use Couscous\Module\Template\Model\HtmlFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -19,16 +19,16 @@ class ProcessTwigLayouts implements Step
 {
     const DEFAULT_LAYOUT_NAME = 'default.twig';
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        if (! $repository->metadata['template.directory']) {
+        if (! $project->metadata['template.directory']) {
             return;
         }
 
-        $twig = $this->createTwig($repository->metadata['template.directory']);
+        $twig = $this->createTwig($project->metadata['template.directory']);
 
         /** @var HtmlFile[] $htmlFiles */
-        $htmlFiles = $repository->findFilesByType('Couscous\Module\Template\Model\HtmlFile');
+        $htmlFiles = $project->findFilesByType('Couscous\Module\Template\Model\HtmlFile');
 
         foreach ($htmlFiles as $file) {
             $fileMetadata = $file->getMetadata();
@@ -37,7 +37,7 @@ class ProcessTwigLayouts implements Step
                 : self::DEFAULT_LAYOUT_NAME;
 
             $context = array_merge(
-                $repository->metadata->toArray(),
+                $project->metadata->toArray(),
                 $fileMetadata->toArray(),
                 ['content' => $file->content]
             );

--- a/src/Module/Template/Step/UseDefaultTemplate.php
+++ b/src/Module/Template/Step/UseDefaultTemplate.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Template\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -25,31 +25,31 @@ class UseDefaultTemplate implements Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        if ($this->useRemoteTemplate($repository)
-            || $this->hasCustomTemplateDirectory($repository)
-            || $this->hasTemplateDirectory($repository)
+        if ($this->useRemoteTemplate($project)
+            || $this->hasCustomTemplateDirectory($project)
+            || $this->hasTemplateDirectory($project)
         ) {
             return;
         }
 
-        $repository->metadata['template.url'] = self::DEFAULT_TEMPLATE_URL;
+        $project->metadata['template.url'] = self::DEFAULT_TEMPLATE_URL;
     }
 
-    private function useRemoteTemplate(Repository $repository)
+    private function useRemoteTemplate(Project $project)
     {
-        return $repository->metadata['template.url'] !== null;
+        return $project->metadata['template.url'] !== null;
     }
 
-    private function hasCustomTemplateDirectory(Repository $repository)
+    private function hasCustomTemplateDirectory(Project $project)
     {
-        return $repository->metadata['template.directory'] !== null;
+        return $project->metadata['template.directory'] !== null;
     }
 
-    private function hasTemplateDirectory(Repository $repository)
+    private function hasTemplateDirectory(Project $project)
     {
-        $templateDirectory = $repository->sourceDirectory . '/' . ValidateTemplateDirectory::DEFAULT_TEMPLATE_DIRECTORY;
+        $templateDirectory = $project->sourceDirectory . '/' . ValidateTemplateDirectory::DEFAULT_TEMPLATE_DIRECTORY;
 
         return $this->filesystem->exists($templateDirectory);
     }

--- a/src/Module/Template/Step/ValidateTemplateDirectory.php
+++ b/src/Module/Template/Step/ValidateTemplateDirectory.php
@@ -2,7 +2,7 @@
 
 namespace Couscous\Module\Template\Step;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Step;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -25,23 +25,23 @@ class ValidateTemplateDirectory implements Step
         $this->filesystem = $filesystem;
     }
 
-    public function __invoke(Repository $repository)
+    public function __invoke(Project $project)
     {
-        $directory = $repository->metadata['template.directory'];
+        $directory = $project->metadata['template.directory'];
 
         if ($directory === null) {
-            $directory = $repository->sourceDirectory . '/' . self::DEFAULT_TEMPLATE_DIRECTORY;
+            $directory = $project->sourceDirectory . '/' . self::DEFAULT_TEMPLATE_DIRECTORY;
         }
 
         if (! $this->filesystem->isAbsolutePath($directory)) {
-            $directory = $repository->sourceDirectory . '/' . $directory;
+            $directory = $project->sourceDirectory . '/' . $directory;
         }
 
         $this->assertDirectoryExist($directory);
 
-        $repository->watchlist->watchDirectory($directory);
+        $project->watchlist->watchDirectory($directory);
 
-        $repository->metadata['template.directory'] = $directory;
+        $project->metadata['template.directory'] = $directory;
     }
 
     private function assertDirectoryExist($directory)

--- a/src/Module/Template/config.php
+++ b/src/Module/Template/config.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+
+    'steps.before' => DI\add([
+        DI\link('Couscous\Module\Template\Step\UseDefaultTemplate'),
+        DI\link('Couscous\Module\Template\Step\FetchRemoteTemplate'),
+        DI\link('Couscous\Module\Template\Step\ValidateTemplateDirectory'),
+    ]),
+    'steps.postprocessing' => DI\add([
+        DI\link('Couscous\Module\Template\Step\LoadAssets'),
+        DI\link('Couscous\Module\Template\Step\AddPageListToLayoutVariables'),
+        DI\link('Couscous\Module\Template\Step\ProcessTwigLayouts'),
+    ]),
+
+];

--- a/src/Step.php
+++ b/src/Step.php
@@ -2,7 +2,7 @@
 
 namespace Couscous;
 
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 
 /**
  * Generation step.
@@ -12,9 +12,9 @@ use Couscous\Model\Repository;
 interface Step
 {
     /**
-     * Process the given repository.
+     * Process the given project.
      *
-     * @param Repository $repository
+     * @param Project $project
      */
-    public function __invoke(Repository $repository);
+    public function __invoke(Project $project);
 }

--- a/tests/UnitTest/GeneratorTest.php
+++ b/tests/UnitTest/GeneratorTest.php
@@ -3,8 +3,8 @@
 namespace Couscous\Tests\UnitTest;
 
 use Couscous\Generator;
-use Couscous\Model\Repository;
-use Couscous\Tests\UnitTest\Mock\MockRepository;
+use Couscous\Model\Project;
+use Couscous\Tests\UnitTest\Mock\MockProject;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -19,17 +19,17 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
     public function it_should_invoke_every_step()
     {
         $filesystem = $this->createFileSystem();
-        $repository = new MockRepository();
+        $project = new MockProject();
 
         $steps = [
-            $this->createStep($repository),
-            $this->createStep($repository),
-            $this->createStep($repository),
+            $this->createStep($project),
+            $this->createStep($project),
+            $this->createStep($project),
         ];
 
         $generator = new Generator($filesystem, $steps);
 
-        $generator->generate($repository, new NullOutput());
+        $generator->generate($project, new NullOutput());
     }
 
     /**
@@ -40,13 +40,13 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Component\Filesystem\Filesystem');
     }
 
-    private function createStep(Repository $repository)
+    private function createStep(Project $project)
     {
         $step = $this->getMockForAbstractClass('Couscous\Step');
 
         $step->expects($this->once())
             ->method('__invoke')
-            ->with($repository);
+            ->with($project);
 
         return $step;
     }

--- a/tests/UnitTest/Mock/MockProject.php
+++ b/tests/UnitTest/Mock/MockProject.php
@@ -3,15 +3,15 @@
 namespace Couscous\Tests\UnitTest\Mock;
 
 use Couscous\Model\Metadata;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 
-class MockRepository extends Repository
+class MockProject extends Project
 {
     public function __construct()
     {
         parent::__construct('', '');
 
-        $this->metadata    = new Metadata();
+        $this->metadata  = new Metadata();
         $this->watchlist = new MockWatchList();
     }
 }

--- a/tests/UnitTest/Model/ProjectTest.php
+++ b/tests/UnitTest/Model/ProjectTest.php
@@ -5,36 +5,36 @@ namespace Couscous\Tests\UnitTest\Model;
 use Couscous\Model\File;
 use Couscous\Module\Template\Model\HtmlFile;
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 
 /**
- * @covers \Couscous\Model\Repository
+ * @covers \Couscous\Model\Project
  */
-class RepositoryTest extends \PHPUnit_Framework_TestCase
+class ProjectTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
      */
     public function it_should_contain_files()
     {
-        $repository = new Repository('source', 'target');
+        $project = new Project('source', 'target');
 
         $file1 = $this->createFile('file1');
         $file2 = $this->createFile('file2');
 
-        $repository->addFile($file1);
-        $repository->addFile($file2);
+        $project->addFile($file1);
+        $project->addFile($file2);
         $expected = [
             'file1' => $file1,
             'file2' => $file2,
         ];
-        $this->assertSame($expected, $repository->getFiles());
+        $this->assertSame($expected, $project->getFiles());
 
-        $repository->removeFile($file1);
-        $this->assertSame(['file2' => $file2], $repository->getFiles());
+        $project->removeFile($file1);
+        $this->assertSame(['file2' => $file2], $project->getFiles());
 
-        $repository->removeFile($file2);
-        $this->assertSame([], $repository->getFiles());
+        $project->removeFile($file2);
+        $this->assertSame([], $project->getFiles());
     }
 
     /**
@@ -42,16 +42,16 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
      */
     public function replace_should_replace_files()
     {
-        $repository = new Repository('source', 'target');
+        $project = new Project('source', 'target');
 
         $file1 = $this->createFile('file1');
         $file2 = $this->createFile('file2');
 
-        $repository->addFile($file1);
-        $this->assertSame(['file1' => $file1], $repository->getFiles());
+        $project->addFile($file1);
+        $this->assertSame(['file1' => $file1], $project->getFiles());
 
-        $repository->replaceFile($file1, $file2);;
-        $this->assertSame(['file2' => $file2], $repository->getFiles());
+        $project->replaceFile($file1, $file2);;
+        $this->assertSame(['file2' => $file2], $project->getFiles());
     }
 
     /**
@@ -59,18 +59,18 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
      */
     public function it_should_return_files_by_type()
     {
-        $repository = new Repository('source', 'target');
+        $project = new Project('source', 'target');
 
         $file1 = new MarkdownFile('file1', 'Hello');
         $file2 = new HtmlFile('file2', 'Hello');
 
-        $repository->addFile($file1);
-        $repository->addFile($file2);
+        $project->addFile($file1);
+        $project->addFile($file2);
 
-        $markdownFiles = $repository->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
+        $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
         $this->assertSame(['file1' => $file1], $markdownFiles);
 
-        $htmlFiles = $repository->findFilesByType('Couscous\Module\Template\Model\HtmlFile');
+        $htmlFiles = $project->findFilesByType('Couscous\Module\Template\Model\HtmlFile');
         $this->assertSame(['file2' => $file2], $htmlFiles);
     }
 

--- a/tests/UnitTest/Module/Config/Step/OverrideBaseUrlForPreviewTest.php
+++ b/tests/UnitTest/Module/Config/Step/OverrideBaseUrlForPreviewTest.php
@@ -3,7 +3,7 @@
 namespace Couscous\Tests\UnitTest\Module\Config\Step;
 
 use Couscous\Module\Config\Step\OverrideBaseUrlForPreview;
-use Couscous\Tests\UnitTest\Mock\MockRepository;
+use Couscous\Tests\UnitTest\Mock\MockProject;
 
 /**
  * @covers \Couscous\Module\Config\Step\OverrideBaseUrlForPreview
@@ -15,14 +15,14 @@ class OverrideBaseUrlForPreviewTest extends \PHPUnit_Framework_TestCase
      */
     public function should_override_baseUrl_if_preview()
     {
-        $repository = new MockRepository();
-        $repository->metadata['baseUrl'] = 'foo';
-        $repository->metadata['preview'] = true;
+        $project = new MockProject();
+        $project->metadata['baseUrl'] = 'foo';
+        $project->metadata['preview'] = true;
 
         $step = new OverrideBaseUrlForPreview();
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $this->assertEquals('', $repository->metadata['baseUrl']);
+        $this->assertEquals('', $project->metadata['baseUrl']);
     }
 
     /**
@@ -30,13 +30,13 @@ class OverrideBaseUrlForPreviewTest extends \PHPUnit_Framework_TestCase
      */
     public function should_not_override_baseUrl_if_not_preview()
     {
-        $repository = new MockRepository();
-        $repository->metadata['baseUrl'] = 'foo';
-        $repository->metadata['preview'] = false;
+        $project = new MockProject();
+        $project->metadata['baseUrl'] = 'foo';
+        $project->metadata['preview'] = false;
 
         $step = new OverrideBaseUrlForPreview();
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $this->assertEquals('foo', $repository->metadata['baseUrl']);
+        $this->assertEquals('foo', $project->metadata['baseUrl']);
     }
 }

--- a/tests/UnitTest/Module/Config/Step/SetDefaultConfigTest.php
+++ b/tests/UnitTest/Module/Config/Step/SetDefaultConfigTest.php
@@ -3,7 +3,7 @@
 namespace Couscous\Tests\UnitTest\Module\Config\Step;
 
 use Couscous\Module\Config\Step\SetDefaultConfig;
-use Couscous\Tests\UnitTest\Mock\MockRepository;
+use Couscous\Tests\UnitTest\Mock\MockProject;
 
 /**
  * @covers \Couscous\Module\Config\Step\SetDefaultConfig
@@ -15,11 +15,11 @@ class SetDefaultConfigTest extends \PHPUnit_Framework_TestCase
      */
     public function it_should_set_default_config()
     {
-        $repository = new MockRepository();
+        $project = new MockProject();
 
         $step = new SetDefaultConfig();
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $this->assertEquals(['vendor', 'website'], $repository->metadata['exclude']);
+        $this->assertEquals(['vendor', 'website'], $project->metadata['exclude']);
     }
 }

--- a/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
@@ -4,7 +4,7 @@ namespace Couscous\Tests\UnitTest\Module\Markdown\Step;
 
 use Couscous\Model\LazyFile;
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Module\Markdown\Step\ProcessMarkdownFileName;
 
 /**
@@ -29,14 +29,14 @@ class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
 
     public function testNonMarkdownFileNotRenamed()
     {
-        $file       = new LazyFile('foo.txt', 'foo.txt');
-        $repository = new Repository('foo', 'bar');
-        $repository->addFile($file);
+        $file    = new LazyFile('foo.txt', 'foo.txt');
+        $project = new Project('foo', 'bar');
+        $project->addFile($file);
 
         $step = new ProcessMarkdownFileName();
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $files = $repository->getFiles();
+        $files = $project->getFiles();
 
         $this->assertCount(1, $files);
         /** @var MarkdownFile $newFile */
@@ -48,14 +48,14 @@ class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
 
     private function assertFileRenamed($expected, $filename)
     {
-        $file       = new MarkdownFile($filename, '');
-        $repository = new Repository('foo', 'bar');
-        $repository->addFile($file);
+        $file    = new MarkdownFile($filename, '');
+        $project = new Project('foo', 'bar');
+        $project->addFile($file);
 
         $step = new ProcessMarkdownFileName();
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $files = $repository->getFiles();
+        $files = $project->getFiles();
 
         $this->assertCount(1, $files);
         /** @var MarkdownFile $newFile */

--- a/tests/UnitTest/Module/Markdown/Step/RewriteMarkdownLinksTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/RewriteMarkdownLinksTest.php
@@ -3,7 +3,7 @@
 namespace Couscous\Tests\UnitTest\Module\Markdown\Step;
 
 use Couscous\Module\Markdown\Model\MarkdownFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Module\Markdown\Step\RewriteMarkdownLinks;
 
 /**
@@ -25,12 +25,12 @@ This is a [link](doc/some-other.file.html), can you handle it (even with these p
 Please leave [this](doc/test.html) and [this link](test.md.txt) alone.
 MARKDOWN;
 
-        $file = new MarkdownFile('foo', $markdown);
-        $repository = new Repository('foo', 'bar');
-        $repository->addFile($file);
+        $file    = new MarkdownFile('foo', $markdown);
+        $project = new Project('foo', 'bar');
+        $project->addFile($file);
 
         $step = new RewriteMarkdownLinks();
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
         $this->assertEquals($expected, $file->content);
     }

--- a/tests/UnitTest/Module/Template/Step/AddPageListToTemplateVariablesTest.php
+++ b/tests/UnitTest/Module/Template/Step/AddPageListToTemplateVariablesTest.php
@@ -3,9 +3,9 @@
 namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Model\HtmlFile;
-use Couscous\Model\Repository;
+use Couscous\Model\Project;
 use Couscous\Module\Template\Step\AddPageListToLayoutVariables;
-use Couscous\Tests\UnitTest\Mock\MockRepository;
+use Couscous\Tests\UnitTest\Mock\MockProject;
 
 /**
  * @covers \Couscous\Module\Template\Step\AddPageListToLayoutVariables
@@ -26,9 +26,9 @@ class AddPageListToTemplateVariablesTest extends \PHPUnit_Framework_TestCase
 
     public function testPageList()
     {
-        $repository = new MockRepository();
+        $project = new MockProject();
 
-        $this->invokeStep($repository, $this->files());
+        $this->invokeStep($project, $this->files());
 
         $expected = [
             'index.html',
@@ -39,14 +39,14 @@ class AddPageListToTemplateVariablesTest extends \PHPUnit_Framework_TestCase
             'weird.path-test [foo]/bar.html',
         ];
 
-        $this->assertEquals($expected, $repository->metadata['pageList']);
+        $this->assertEquals($expected, $project->metadata['pageList']);
     }
 
     public function testPageTree()
     {
-        $repository = new MockRepository();
+        $project = new MockProject();
 
-        $this->invokeStep($repository, $this->files());
+        $this->invokeStep($project, $this->files());
 
         $expected = [
             'docs' => [
@@ -67,16 +67,16 @@ class AddPageListToTemplateVariablesTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $repository->metadata['pageTree']);
+        $this->assertEquals($expected, $project->metadata['pageTree']);
     }
 
-    private function invokeStep(Repository $repository, $files)
+    private function invokeStep(Project $project, $files)
     {
         foreach ($files as $file) {
-            $repository->addFile($file);
+            $project->addFile($file);
         }
 
         $step = new AddPageListToLayoutVariables();
-        $step->__invoke($repository);
+        $step->__invoke($project);
     }
 }

--- a/tests/UnitTest/Module/Template/Step/FetchRemoteTemplateTest.php
+++ b/tests/UnitTest/Module/Template/Step/FetchRemoteTemplateTest.php
@@ -3,7 +3,7 @@
 namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\FetchRemoteTemplate;
-use Couscous\Tests\UnitTest\Mock\MockRepository;
+use Couscous\Tests\UnitTest\Mock\MockProject;
 use Psr\Log\NullLogger;
 
 /**
@@ -21,14 +21,14 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
 
         $step = new FetchRemoteTemplate($filesystem, $commandRunner, new NullLogger());
 
-        $repository = new MockRepository();
+        $project = new MockProject();
 
         $commandRunner->expects($this->never())
             ->method('run');
 
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $this->assertNull($repository->metadata['template.directory']);
+        $this->assertNull($project->metadata['template.directory']);
     }
 
     /**
@@ -41,16 +41,16 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
 
         $step = new FetchRemoteTemplate($filesystem, $commandRunner, new NullLogger());
 
-        $repository = new MockRepository();
-        $repository->metadata['template.url'] = 'git://foo';
+        $project = new MockProject();
+        $project->metadata['template.url'] = 'git://foo';
 
         $commandRunner->expects($this->once())
             ->method('run')
             ->with($this->matches('git clone git://foo %s'));
 
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $this->assertNotNull($repository->metadata['template.directory']);
+        $this->assertNotNull($project->metadata['template.directory']);
     }
 
     /**
@@ -68,16 +68,16 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
             ->with($this->matches('git clone git://foo %s'));
 
         // Calling once
-        $repository = new MockRepository();
-        $repository->metadata['template.url'] = 'git://foo';
-        $step->__invoke($repository);
-        $this->assertNotNull($repository->metadata['template.directory']);
+        $project = new MockProject();
+        $project->metadata['template.url'] = 'git://foo';
+        $step->__invoke($project);
+        $this->assertNotNull($project->metadata['template.directory']);
 
         // Calling twice
-        $repository = new MockRepository();
-        $repository->regenerate = true;
-        $repository->metadata['template.url'] = 'git://foo';
-        $step->__invoke($repository);
-        $this->assertNotNull($repository->metadata['template.directory']);
+        $project = new MockProject();
+        $project->regenerate = true;
+        $project->metadata['template.url'] = 'git://foo';
+        $step->__invoke($project);
+        $this->assertNotNull($project->metadata['template.directory']);
     }
 }

--- a/tests/UnitTest/Module/Template/Step/UseDefaultTemplateTest.php
+++ b/tests/UnitTest/Module/Template/Step/UseDefaultTemplateTest.php
@@ -3,7 +3,7 @@
 namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\UseDefaultTemplate;
-use Couscous\Tests\UnitTest\Mock\MockRepository;
+use Couscous\Tests\UnitTest\Mock\MockProject;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -18,10 +18,10 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
     {
         $step = new UseDefaultTemplate($this->createFilesystem());
 
-        $repository = new MockRepository();
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $step->__invoke($project);
 
-        $this->assertEquals(UseDefaultTemplate::DEFAULT_TEMPLATE_URL, $repository->metadata['template.url']);
+        $this->assertEquals(UseDefaultTemplate::DEFAULT_TEMPLATE_URL, $project->metadata['template.url']);
     }
 
     /**
@@ -31,10 +31,10 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
     {
         $step = new UseDefaultTemplate($this->createFilesystem(true));
 
-        $repository = new MockRepository();
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $step->__invoke($project);
 
-        $this->assertNull($repository->metadata['template.url']);
+        $this->assertNull($project->metadata['template.url']);
     }
 
     /**
@@ -44,12 +44,12 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
     {
         $step = new UseDefaultTemplate($this->createFilesystem());
 
-        $repository = new MockRepository();
-        $repository->metadata['template.directory'] = 'foo';
+        $project = new MockProject();
+        $project->metadata['template.directory'] = 'foo';
 
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
-        $this->assertNull($repository->metadata['template.url']);
+        $this->assertNull($project->metadata['template.url']);
     }
 
     /**
@@ -59,13 +59,13 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
     {
         $step = new UseDefaultTemplate($this->createFilesystem());
 
-        $repository = new MockRepository();
-        $repository->metadata['template.url'] = 'foo';
+        $project = new MockProject();
+        $project->metadata['template.url'] = 'foo';
 
-        $step->__invoke($repository);
+        $step->__invoke($project);
 
         // Assert URL isn't overridden
-        $this->assertEquals('foo', $repository->metadata['template.url']);
+        $this->assertEquals('foo', $project->metadata['template.url']);
     }
 
     /**

--- a/tests/UnitTest/Module/Template/Step/ValidateTemplateDirectoryTest.php
+++ b/tests/UnitTest/Module/Template/Step/ValidateTemplateDirectoryTest.php
@@ -3,7 +3,7 @@
 namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\ValidateTemplateDirectory;
-use Couscous\Tests\UnitTest\Mock\MockRepository;
+use Couscous\Tests\UnitTest\Mock\MockProject;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -17,11 +17,11 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_use_the_default_directory_if_no_directory_is_set()
     {
         $step = new ValidateTemplateDirectory($this->createFilesystem());
-        $repository = new MockRepository();
-        $repository->sourceDirectory = '/foo';
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $project->sourceDirectory = '/foo';
+        $step->__invoke($project);
 
-        $this->assertEquals('/foo/website', $repository->metadata['template.directory']);
+        $this->assertEquals('/foo/website', $project->metadata['template.directory']);
     }
 
     /**
@@ -30,12 +30,12 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_complete_a_relative_path()
     {
         $step = new ValidateTemplateDirectory($this->createFilesystem());
-        $repository = new MockRepository();
-        $repository->sourceDirectory = '/foo';
-        $repository->metadata['template.directory'] = 'bar';
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $project->sourceDirectory = '/foo';
+        $project->metadata['template.directory'] = 'bar';
+        $step->__invoke($project);
 
-        $this->assertEquals('/foo/bar', $repository->metadata['template.directory']);
+        $this->assertEquals('/foo/bar', $project->metadata['template.directory']);
     }
 
     /**
@@ -44,12 +44,12 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_not_change_an_absolute_path()
     {
         $step = new ValidateTemplateDirectory($this->createFilesystem());
-        $repository = new MockRepository();
-        $repository->sourceDirectory = '/foo';
-        $repository->metadata['template.directory'] = '/hello/world';
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $project->sourceDirectory = '/foo';
+        $project->metadata['template.directory'] = '/hello/world';
+        $step->__invoke($project);
 
-        $this->assertEquals('/hello/world', $repository->metadata['template.directory']);
+        $this->assertEquals('/hello/world', $project->metadata['template.directory']);
     }
 
     /**
@@ -60,10 +60,10 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_error_with_an_invalid_relative_path()
     {
         $step = new ValidateTemplateDirectory($this->createFilesystem(false));
-        $repository = new MockRepository();
-        $repository->sourceDirectory = '/foo';
-        $repository->metadata['template.directory'] = 'bar';
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $project->sourceDirectory = '/foo';
+        $project->metadata['template.directory'] = 'bar';
+        $step->__invoke($project);
     }
 
     /**
@@ -74,10 +74,10 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_error_with_an_invalid_absolute_path()
     {
         $step = new ValidateTemplateDirectory($this->createFilesystem(false));
-        $repository = new MockRepository();
-        $repository->sourceDirectory = '/foo';
-        $repository->metadata['template.directory'] = '/hello/world';
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $project->sourceDirectory = '/foo';
+        $project->metadata['template.directory'] = '/hello/world';
+        $step->__invoke($project);
     }
 
     /**
@@ -88,9 +88,9 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
     public function it_should_error_with_an_invalid_default_path()
     {
         $step = new ValidateTemplateDirectory($this->createFilesystem(false));
-        $repository = new MockRepository();
-        $repository->sourceDirectory = '/foo';
-        $step->__invoke($repository);
+        $project = new MockProject();
+        $project->sourceDirectory = '/foo';
+        $step->__invoke($project);
     }
 
     /**


### PR DESCRIPTION
This is a follow up of #66 

Modules now register their own "generation steps". This would allow to have 3rd party modules to extend Couscous (e.g. rST support, Bower, Less, BlogModule, …). This is similar to Symfony bundles: modules now come with container configs.

Also, I've renamed `Repository` to `Project` as I feel it's more explicit (should have done that in a separate PR, sorry).

For example, here is the Bower module configuration:

```php
<?php
return [
    'steps.preprocessing' => DI\add([
        DI\link('Couscous\Module\Bower\Step\RunBowerInstall'),
    ]),
];
```