### PR TITLE
New template: Read The Docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "symfony/process": "~2.4",
         "symfony/yaml": "~2.4",
         "twig/twig": "~1.0",
-        "erusev/parsedown": "~1.4",
         "erusev/parsedown-extra": "~0.7",
         "phine/phar": "~1.0",
         "mnapoli/front-yaml": "~1.4",

--- a/couscous.yml
+++ b/couscous.yml
@@ -9,8 +9,6 @@ exclude:
 scripts:
     before:
         - lessc --clean-css website/less/main.less website/css/all.min.css
-    after:
-        - rm website/couscous.phar
 
 baseUrl: http://couscous.io
 

--- a/website/less/templates.less
+++ b/website/less/templates.less
@@ -1,10 +1,20 @@
 #templates.portfolio .portfolio-item {
   .template-features {
     .label {
-      font-size: 75%;
+      font-size: 70%;
       font-weight: normal;
       font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
       font-style: normal;
+    }
+  }
+  .portfolio-caption {
+    padding: 25px 15px;
+
+    .label {
+      opacity: 0.7;
+    }
+    .label:hover {
+      opacity: 1;
     }
   }
 }

--- a/website/templates.twig
+++ b/website/templates.twig
@@ -30,7 +30,8 @@
                         <p class="text-muted">The default template.</p>
                         <p class="template-features">
                             <span class="label label-default">optional menu</span>
-                            <span class="label label-default">syntax highlighting</span>
+                            <span class="label label-default">code highlighting</span>
+                            <span class="label label-default">responsive</span>
                         </p>
                     </div>
                 </div>
@@ -50,7 +51,8 @@
                         <p class="template-features">
                             <span class="label label-default">optional menu</span>
                             <span class="label label-default">sections</span>
-                            <span class="label label-default">syntax highlighting</span>
+                            <span class="label label-default">code highlighting</span>
+                            <span class="label label-default">responsive</span>
                         </p>
                     </div>
                 </div>
@@ -68,7 +70,8 @@
                         <h4>Basic template</h4>
                         <p class="text-muted">A basic template example.</p>
                         <p class="template-features">
-                            <span class="label label-default">syntax highlighting</span>
+                            <span class="label label-default">code highlighting</span>
+                            <span class="label label-default">responsive</span>
                         </p>
                     </div>
                 </div>
@@ -78,7 +81,27 @@
             <div class="row">
 
                 <div class="col-md-4 col-sm-6 portfolio-item">
-                    <a href="https://github.com/CouscousPHP/Couscous" class="portfolio-link">
+                    <a href="https://github.com/CouscousPHP/Template-ReadTheDocs" class="portfolio-link">
+                        <div class="portfolio-hover">
+                            <div class="portfolio-hover-content">
+                                <i class="fa fa-search fa-3x"></i>
+                            </div>
+                        </div>
+                        <img src="https://raw.githubusercontent.com/CouscousPHP/Template-ReadTheDocs/master/screenshot.png" class="img-responsive">
+                    </a>
+                    <div class="portfolio-caption">
+                        <h4>Read The Docs template</h4>
+                        <p class="text-muted">template based on readthedocs.org Sphinx theme.</p>
+                        <p class="template-features">
+                            <span class="label label-default">menu</span>
+                            <span class="label label-default">code highlighting</span>
+                            <span class="label label-default">responsive</span>
+                        </p>
+                    </div>
+                </div>
+
+                <div class="col-md-4 col-sm-6 portfolio-item">
+                    <a href="https://github.com/CouscousPHP/Couscous/blob/master/website/templates.twig" class="portfolio-link">
                         <div class="portfolio-hover">
                             <div class="portfolio-hover-content">
                                 <i class="fa fa-search fa-3x"></i>
@@ -88,7 +111,9 @@
                     </a>
                     <div class="portfolio-caption">
                         <h4>Add your own</h4>
-                        <p class="text-muted">Send a pull request to add your own to the list.</p>
+                        <p class="text-muted">
+                            <a href="https://github.com/CouscousPHP/Couscous/blob/master/website/templates.twig">Send a pull request</a> to add your own to the list.
+                        </p>
                     </div>
                 </div>
 


### PR DESCRIPTION
Hey everyone, here's a new template!

This one is a fork of the Sphinx theme used by [Read The Docs](http://readthedocs.org/). That original theme is licensed with MIT so we are allowed to fork it! For example Guzzle is on Read The Docs: [guzzle.readthedocs.org](http://guzzle.readthedocs.org/en/latest/).

Here is the repository: https://github.com/CouscousPHP/Template-ReadTheDocs

I think having a new template along the new (future) 1.1 version will help spread the word ;)

Screenshot:

[![](https://raw.githubusercontent.com/CouscousPHP/Template-ReadTheDocs/master/screenshot.png)](https://github.com/CouscousPHP/Template-ReadTheDocs)