### PR TITLE
adds an init:template command (fix #40)

### DIFF
--- a/src/Application/Cli/InitTemplateCommand.php
+++ b/src/Application/Cli/InitTemplateCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Couscous\Application\Cli;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Initialize a new Couscous template.
+ *
+ * @author Ross J. Hagan <rossjhagan@gmail.com>
+ */
+class InitTemplateCommand extends Command {
+
+    protected function configure()
+    {
+        $this
+            ->setName('init:template')
+            ->setDescription('Initialize a new Couscous template');
+
+        $this->addArgument(
+            'template_name',
+            InputArgument::REQUIRED,
+            'Template name'
+        )
+        ->addArgument(
+            'directory',
+            InputArgument::OPTIONAL,
+            'Directory name',
+            'website'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+
+        $fileExtension  = '.twig';
+
+        $dirName        = $input->getArgument('directory');
+        $directory      = getcwd() . '/' . $dirName . '/';
+        $templateName   = $input->getArgument('template_name') . $fileExtension;
+
+        $fileLocation   = $directory . $templateName;
+        $fileExists     = file_exists($fileLocation);
+
+        if (! file_exists(getcwd() . '/' . $dirName)) {
+            $output->writeln('<comment>Creating directory.</comment>');
+            mkdir(getcwd() . '/' . $dirName);
+        }
+
+        if ($fileExists) {
+            $output->writeln('<error>That template exists at ' . $fileLocation . ', so nothing has been changed.</error>');
+            $output->writeln('<error>Try another name!</error>');
+            return;
+        }
+
+        if (! $fileExists) {
+            $output->writeln('<comment>Initialising template.</comment>');
+            $template = <<<HTML
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My project!</title>
+    </head>
+    <body>
+
+        {% block content %}
+
+        <p>
+            Don't forget you can add variables into your YAML front matter, or in your couscous.yml
+            then use them inside double curly braces!
+        </p>
+
+        <p>
+            Also, set up a baseUrl in your couscous.yml and use it
+            to <a href="{{ baseUrl }}/link/in/the/site">link to another page</a> in your site
+        </p>
+
+            {{ content|raw }}
+
+        {% endblock %}
+
+    </body>
+</html>
+HTML;
+            file_put_contents($fileLocation, $template);
+        }
+
+    }
+
+}

--- a/src/Application/config.php
+++ b/src/Application/config.php
@@ -40,6 +40,7 @@ return [
         $application->add($c->get('Couscous\Application\Cli\DeployCommand'));
         $application->add($c->get('Couscous\Application\Cli\ClearCommand'));
         $application->add($c->get('Couscous\Application\Cli\TravisAutoDeployCommand'));
+        $application->add($c->get('Couscous\Application\Cli\InitTemplateCommand'));
 
         return $application;
     }),


### PR DESCRIPTION
Not sure how much detail was/is wanted with an initial template.  

It offers an optional second argument for specifying the directory to place the template in, defaulting to 'website'.

Perhaps it would be better to read that from the yaml configuration?

Also, no documentation added with this (contrary to contributing.md, sorry).  It seems fairly self-documenting, but let me know if you think docs would be appropriate and where to put them.