### PR TITLE
Documentation fixes for #94, #95 and #105

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,3 +40,11 @@ baseUrl: http://username.github.io/your-project
 ```
 
 **Note:** any variable you put in `couscous.yml` is called **Metadata**. You can use these variables in templates for example. Learn more about this in the [Metadata documentation](metadata.md).
+
+## Using a Domain Name with Github Pages and Couscous
+
+To use a CNAME for your Couscous-generated documentation so that your docs point to `docs.yourdomain.com` or something similar, first create the CNAME file and point your DNS to `yourname.github.io`, as detailed in the [Github documentation](https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/).
+
+To deploy the CNAME file to your `gh-pages` branch automatically with Couscous, simply put the CNAME file in the `website` directory (or whatever template directory you configured) in `couscous.yml`.
+
+Note that this will only work if the you're using embedded templates (versus remote templates). If you're using remote templates, you'll need to copy the remote templates to your repository and configure your `couscous.yml` file to use the embedded template instead.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,6 +53,15 @@ Be assured that this command will not modify your repository.
 
 Liking what you see? The default template comes with a header and an optional left menu (which is hidden if it is not configured). You can configure all that [by creating a `couscous.yml`](configuration.md) and checking out all the options [on the template's homepage](https://github.com/CouscousPHP/Template-Light).
 
+#### Specify an Address
+
+While the default `couscous deploy` address will work on most installations, there may be times where you need to specify the preview IP address (for example if using VM or container tools like Vagrant or Docker). To specify an address, in this example `0.0.0.0:8000`, use:
+
+```
+couscous preview 0.0.0.0:8000
+```
+
+
 ## Deploy
 
 Happy with the result? Here is how to deploy:
@@ -66,6 +75,14 @@ Couscous will generate the website (in a temp directory) and publish it in the `
 The website is now online: [http://your-username.github.io/your-project/](http://your-username.github.io/your-project/).
 
 The `deploy` command will not change anything in your current branch (e.g. master branch). It will only affect the `gh-pages` branch.
+
+#### Deploying to a branch other than `gh-pages`
+
+If you wish to have Couscous generate and deploy pages to a branch other than `gh-pages`, use the `--branch` option. For example:
+
+```
+couscous.phar deploy --branch master
+```
 
 ## Customizing the template
 


### PR DESCRIPTION
Just some quick updates to the documentation regarding CNAMEs, the preview IP address and deploying to a branch other than `gh-pages`.