### PR TITLE
Fix compatibility issues with Windows

### DIFF
--- a/src/CommandRunner/Git.php
+++ b/src/CommandRunner/Git.php
@@ -36,7 +36,7 @@ class Git
 
     public function commitAllChanges($directory, $message)
     {
-        $this->run($directory, "git add --all . && git commit -m '$message'");
+        $this->run($directory, "git add --all . && git commit -m \"$message\"");
     }
 
     public function push($directory, $branch, $remote = 'origin')

--- a/tests/UnitTest/CommandRunner/GitTest.php
+++ b/tests/UnitTest/CommandRunner/GitTest.php
@@ -64,7 +64,7 @@ class GitTest extends \PHPUnit_Framework_TestCase
      */
     public function commit_should_run_git_add_and_commit()
     {
-        $this->expectCommandIsRun("cd \"directory\" && git add --all . && git commit -m 'message'");
+        $this->expectCommandIsRun("cd \"directory\" && git add --all . && git commit -m \"message\"");
 
         $this->git->commitAllChanges('directory', 'message');
     }


### PR DESCRIPTION
See #115. Single quotes are tricky in Windows' built-in command processor, so this converts them to double quotes.