### PR TITLE
Added support to render other files as home page than README.md

### DIFF
--- a/src/Module/Markdown/Step/ProcessMarkdownFileName.php
+++ b/src/Module/Markdown/Step/ProcessMarkdownFileName.php
@@ -13,8 +13,14 @@ use Couscous\Step;
  */
 class ProcessMarkdownFileName implements Step
 {
+
+    private $project;
+
     public function __invoke(Project $project)
     {
+
+        $this->project = $project;
+
         /** @var MarkdownFile[] $markdownFiles */
         $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
 
@@ -36,7 +42,13 @@ class ProcessMarkdownFileName implements Step
 
     private function renameReadme(MarkdownFile $file)
     {
-        if ($file->getBasename() !== 'README.html') {
+
+        if(
+          !empty($this->project->metadata['index']) &&
+          $file->getBasename() !== $this->replaceExtension(basename($this->project->metadata['index'])))
+        {
+          return;
+        } else if(empty($this->project->metadata['index']) && $file->getBasename() !== 'README.html') {
             return;
         }
 

--- a/src/Module/Markdown/Step/ProcessMarkdownFileName.php
+++ b/src/Module/Markdown/Step/ProcessMarkdownFileName.php
@@ -13,14 +13,8 @@ use Couscous\Step;
  */
 class ProcessMarkdownFileName implements Step
 {
-
-    private $project;
-
     public function __invoke(Project $project)
     {
-
-        $this->project = $project;
-
         /** @var MarkdownFile[] $markdownFiles */
         $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
 
@@ -28,7 +22,7 @@ class ProcessMarkdownFileName implements Step
             $project->removeFile($markdownFile);
 
             $this->renameFileExtension($markdownFile);
-            $this->renameReadme($markdownFile);
+            $this->renameReadme($markdownFile, $project);
             $this->renameFilename($markdownFile);
 
             $project->addFile($markdownFile);
@@ -40,15 +34,11 @@ class ProcessMarkdownFileName implements Step
         $file->relativeFilename = $this->replaceExtension($file->relativeFilename);
     }
 
-    private function renameReadme(MarkdownFile $file)
+    private function renameReadme(MarkdownFile $file, Project $project)
     {
-
-        if(
-          !empty($this->project->metadata['index']) &&
-          $file->getBasename() !== $this->replaceExtension(basename($this->project->metadata['index'])))
-        {
-          return;
-        } else if(empty($this->project->metadata['index']) && $file->getBasename() !== 'README.html') {
+        $indexFile = empty($project->metadata['template']['index']) ? 'README.md' : $project->metadata['template']['index'];
+        $indexFile = $this->replaceExtension(basename($indexFile));
+        if ($file->getBasename() !== $indexFile) {
             return;
         }
 

--- a/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
@@ -3,8 +3,8 @@
 namespace Couscous\Tests\UnitTest\Module\Markdown\Step;
 
 use Couscous\Model\LazyFile;
-use Couscous\Model\Project;
 use Couscous\Model\Metadata;
+use Couscous\Model\Project;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Module\Markdown\Step\ProcessMarkdownFileName;
 
@@ -69,9 +69,9 @@ class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
         $project = new Project('foo', 'bar');
         $project->addFile($file);
 
-        if($meta) {
-          $project->metadata = new Metadata();
-          $project->metadata->setMany(['index' => 'foo/index.md']);
+        if ($meta) {
+            $project->metadata = new Metadata();
+            $project->metadata->setMany(['template' => ['index' => 'foo/index.md']]);
         }
 
         $step = new ProcessMarkdownFileName();

--- a/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
@@ -3,6 +3,7 @@
 namespace Couscous\Tests\UnitTest\Module\Markdown\Step;
 
 use Couscous\Model\LazyFile;
+use Couscous\Model\Metadata;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Model\Project;
 use Couscous\Module\Markdown\Step\ProcessMarkdownFileName;
@@ -25,6 +26,12 @@ class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
     public function testRenameReadme()
     {
         $this->assertFileRenamed('index.html', 'README.md');
+    }
+
+    public function testRenameIndexFile()
+    {
+        $this->assertFileRenamed('foo/index.html', 'foo/index.md', true);
+        $this->assertFileRenamed('readme.html', 'README.md', true);
     }
 
     public function testRenameReadmeInSubDirectory()
@@ -56,11 +63,16 @@ class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($newFile, $file);
     }
 
-    private function assertFileRenamed($expected, $filename)
+    private function assertFileRenamed($expected, $filename, $meta = false)
     {
         $file    = new MarkdownFile($filename, '');
         $project = new Project('foo', 'bar');
         $project->addFile($file);
+
+        if($meta) {
+          $project->metadata = new Metadata();
+          $project->metadata->setMany(['index' => 'foo/index.md']);
+        }
 
         $step = new ProcessMarkdownFileName();
         $step->__invoke($project);


### PR DESCRIPTION
Well, as I asked in #121, I'm looking for a way to show the home page but not using the README.md file.


The idea is to specify in the `couscous.yml` file:

```yml
index: index.md
```

And so Couscous should use `index.md` instead of `README.md`.

I don't know if my implementation is right, sorry about that. Maybe someone should take a look.

BTW I loved the project name, here in Brazil we call "cuscuz". I think I'm hungry.

I hope this PR helps, thank you.