### PR TITLE
Add a metadata to generate a CNAME file

### DIFF
--- a/src/Application/config.php
+++ b/src/Application/config.php
@@ -35,6 +35,7 @@ return [
 
         DI\get('Couscous\Module\Core\Step\ClearTargetDirectory'),
         DI\get('Couscous\Module\Core\Step\WriteFiles'),
+        DI\get('Couscous\Module\Core\Step\AddCname'),
 
         DI\get('Couscous\Module\Scripts\Step\ExecuteAfterScripts'),
     ],

--- a/src/Application/config.php
+++ b/src/Application/config.php
@@ -21,6 +21,7 @@ return [
         DI\get('Couscous\Module\Markdown\Step\LoadMarkdownFiles'),
         DI\get('Couscous\Module\Template\Step\LoadAssets'),
         DI\get('Couscous\Module\Core\Step\AddImages'),
+        DI\get('Couscous\Module\Core\Step\AddCname'),
 
         DI\get('Couscous\Module\Core\Step\AddFileNameToMetadata'),
 
@@ -35,7 +36,6 @@ return [
 
         DI\get('Couscous\Module\Core\Step\ClearTargetDirectory'),
         DI\get('Couscous\Module\Core\Step\WriteFiles'),
-        DI\get('Couscous\Module\Core\Step\AddCname'),
 
         DI\get('Couscous\Module\Scripts\Step\ExecuteAfterScripts'),
     ],

--- a/src/Module/Core/Step/AddCname.php
+++ b/src/Module/Core/Step/AddCname.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Couscous\Module\Core\Step;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Writes the generated files to disk.
+ *
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class AddCname implements Step
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(Filesystem $filesystem, LoggerInterface $logger)
+    {
+        $this->filesystem = $filesystem;
+        $this->logger = $logger;
+    }
+
+    public function __invoke(Project $project)
+    {
+        if( isset($project->metadata['cname']) ){
+            $this->filesystem->dumpFile( $project->targetDirectory.'/'.'CNAME', $project->metadata['cname'] );
+            $this->logger->notice('Writing metadata CNAME');
+        }
+    }
+}

--- a/src/Module/Core/Step/AddCname.php
+++ b/src/Module/Core/Step/AddCname.php
@@ -32,7 +32,7 @@ class AddCname implements Step
 
     public function __invoke(Project $project)
     {
-        if(isset($project->metadata['cname'])){
+        if (isset($project->metadata['cname'])) {
             $this->filesystem->dumpFile( $project->targetDirectory.'/'.'CNAME', $project->metadata['cname']);
             $this->logger->notice('Writing metadata CNAME');
         }

--- a/src/Module/Core/Step/AddCname.php
+++ b/src/Module/Core/Step/AddCname.php
@@ -4,37 +4,21 @@ namespace Couscous\Module\Core\Step;
 
 use Couscous\Model\Project;
 use Couscous\Step;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Filesystem\Filesystem;
+use Couscous\Module\Template\Model\CnameFile;
 
 /**
- * Writes the generated files to disk.
+ * Adds the CNAME file to project
  *
- * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ * @author Leonardo Ruhland <leoruhland@gmail.com>
  */
+
 class AddCname implements Step
 {
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    public function __construct(Filesystem $filesystem, LoggerInterface $logger)
-    {
-        $this->filesystem = $filesystem;
-        $this->logger = $logger;
-    }
 
     public function __invoke(Project $project)
     {
         if (isset($project->metadata['cname'])) {
-            $this->filesystem->dumpFile($project->targetDirectory.'/'.'CNAME', $project->metadata['cname']);
-            $this->logger->notice('Writing metadata CNAME');
+            $project->addFile(new CnameFile('CNAME', $project->metadata['cname']));
         }
     }
 }

--- a/src/Module/Core/Step/AddCname.php
+++ b/src/Module/Core/Step/AddCname.php
@@ -33,7 +33,7 @@ class AddCname implements Step
     public function __invoke(Project $project)
     {
         if (isset($project->metadata['cname'])) {
-            $this->filesystem->dumpFile( $project->targetDirectory.'/'.'CNAME', $project->metadata['cname']);
+            $this->filesystem->dumpFile($project->targetDirectory.'/'.'CNAME', $project->metadata['cname']);
             $this->logger->notice('Writing metadata CNAME');
         }
     }

--- a/src/Module/Core/Step/AddCname.php
+++ b/src/Module/Core/Step/AddCname.php
@@ -32,8 +32,8 @@ class AddCname implements Step
 
     public function __invoke(Project $project)
     {
-        if( isset($project->metadata['cname']) ){
-            $this->filesystem->dumpFile( $project->targetDirectory.'/'.'CNAME', $project->metadata['cname'] );
+        if(isset($project->metadata['cname'])){
+            $this->filesystem->dumpFile( $project->targetDirectory.'/'.'CNAME', $project->metadata['cname']);
             $this->logger->notice('Writing metadata CNAME');
         }
     }

--- a/src/Module/Core/Step/AddCname.php
+++ b/src/Module/Core/Step/AddCname.php
@@ -3,18 +3,16 @@
 namespace Couscous\Module\Core\Step;
 
 use Couscous\Model\Project;
-use Couscous\Step;
 use Couscous\Module\Template\Model\CnameFile;
+use Couscous\Step;
 
 /**
- * Adds the CNAME file to project
+ * Adds the CNAME file to project.
  *
  * @author Leonardo Ruhland <leoruhland@gmail.com>
  */
-
 class AddCname implements Step
 {
-
     public function __invoke(Project $project)
     {
         if (isset($project->metadata['cname'])) {

--- a/src/Module/Template/Model/CnameFile.php
+++ b/src/Module/Template/Model/CnameFile.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Module\Template\Model;
+
+use Couscous\Model\File;
+
+/**
+ * @author Matthieu Napoli <matthieu@mnapoli.fr>
+ */
+class CnameFile extends File
+{
+    /**
+     * @var string
+     */
+    public $content;
+
+    public function __construct($relativeFilename, $content)
+    {
+        parent::__construct($relativeFilename);
+
+        $this->content = $content;
+    }
+
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/tests/UnitTest/Module/Core/Step/AddCnameTest.php
+++ b/tests/UnitTest/Module/Core/Step/AddCnameTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace Couscous\Tests\UnitTest\Module\Template\Step;
+
+use Couscous\Model\File;
+use Couscous\Module\Core\Step\AddCname;
+use Couscous\Model\Metadata;
+use Couscous\Model\Project;
+/**
+ * @covers \Couscous\Model\Project
+ */
+class AddCnameTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_add_the_cname_file()
+    {
+        $project = new Project('foo', 'bar');
+
+        $project->metadata = new Metadata();
+        $project->metadata['cname'] = 'http://www.couscous.io';
+
+        $step = new AddCname();
+        $step->__invoke($project);
+
+        $cnameFiles = $project->findFilesByType('Couscous\Module\Template\Model\CnameFile');
+
+        $this->assertCount(1, $cnameFiles);
+
+        $this->assertEquals($cnameFiles['CNAME']->content, $project->metadata['cname']);
+    }
+}

--- a/tests/UnitTest/Module/Core/Step/AddCnameTest.php
+++ b/tests/UnitTest/Module/Core/Step/AddCnameTest.php
@@ -1,10 +1,10 @@
 <?php
+
 namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
-use Couscous\Model\File;
-use Couscous\Module\Core\Step\AddCname;
 use Couscous\Model\Metadata;
 use Couscous\Model\Project;
+use Couscous\Module\Core\Step\AddCname;
 /**
  * @covers \Couscous\Model\Project
  */

--- a/tests/UnitTest/Module/Core/Step/AddCnameTest.php
+++ b/tests/UnitTest/Module/Core/Step/AddCnameTest.php
@@ -5,6 +5,7 @@ namespace Couscous\Tests\UnitTest\Module\Template\Step;
 use Couscous\Model\Metadata;
 use Couscous\Model\Project;
 use Couscous\Module\Core\Step\AddCname;
+
 /**
  * @covers \Couscous\Model\Project
  */


### PR DESCRIPTION
This fixes the problem with CNAME and remote templates which is mentioned in the docs/configuration. Setting a cname metadata in couscous.yml generates a CNAME file.

If you find a good idea, I can add some documentation and provide some tests too.