### PR TITLE
Add metadata to generate a CNAME file

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -11,6 +11,7 @@ scripts:
         - lessc --clean-css website/less/main.less website/css/all.min.css
 
 baseUrl: http://couscous.io
+cname: couscous.io
 
 menu:
     items:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,10 @@ scripts:
     after:
         - rm website/couscous.phar
 
+# Set this variable to use a Custom Domain
+# The content of this variable will be directly inserted into the CNAME file
+cname: docs.yourdomain.com
+
 # Any variable you put in this file is also available in the Twig layouts:
 title: Hello!
 
@@ -45,8 +49,4 @@ baseUrl: http://username.github.io/your-project
 
 ## Using a Domain Name with Github Pages and Couscous
 
-To use a CNAME for your Couscous-generated documentation so that your docs point to `docs.yourdomain.com` or something similar, first create the CNAME file and point your DNS to `yourname.github.io`, as detailed in the [Github documentation](https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/).
-
-To deploy the CNAME file to your `gh-pages` branch automatically with Couscous, simply put the CNAME file in the `website` directory (or whatever template directory you configured) in `couscous.yml`.
-
-Note that this will only work if the you're using embedded templates (versus remote templates). If you're using remote templates, you'll need to copy the remote templates to your repository and configure your `couscous.yml` file to use the embedded template instead.
+To use a CNAME for your Couscous-generated documentation so that your docs point to `docs.yourdomain.com` or something similar, set the `cname` variable described above and point your DNS to `yourname.github.io`, as detailed in the [Github documentation](https://help.github.com/articles/setting-up-a-custom-domain-with-github-pages/).

--- a/src/Application/config.php
+++ b/src/Application/config.php
@@ -21,6 +21,7 @@ return [
         DI\get('Couscous\Module\Markdown\Step\LoadMarkdownFiles'),
         DI\get('Couscous\Module\Template\Step\LoadAssets'),
         DI\get('Couscous\Module\Core\Step\AddImages'),
+        DI\get('Couscous\Module\Core\Step\AddCname'),
 
         DI\get('Couscous\Module\Core\Step\AddFileNameToMetadata'),
 

--- a/src/Module/Core/Step/AddCname.php
+++ b/src/Module/Core/Step/AddCname.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Couscous\Module\Core\Step;
+
+use Couscous\Model\Project;
+use Couscous\Module\Template\Model\CnameFile;
+use Couscous\Step;
+
+/**
+ * Add the CNAME file to project.
+ *
+ * @author Leonardo Ruhland <leoruhland@gmail.com>
+ */
+class AddCname implements Step
+{
+    public function __invoke(Project $project)
+    {
+        if (isset($project->metadata['cname'])) {
+            $project->addFile(new CnameFile('CNAME', $project->metadata['cname']));
+        }
+    }
+}

--- a/src/Module/Template/Model/CnameFile.php
+++ b/src/Module/Template/Model/CnameFile.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Module\Template\Model;
+
+use Couscous\Model\File;
+
+/**
+ * @author Leonardo Ruhland <leoruhland@gmail.com>
+ */
+class CnameFile extends File
+{
+    /**
+     * @var string
+     */
+    public $content;
+
+    public function __construct($relativeFilename, $content)
+    {
+        parent::__construct($relativeFilename);
+
+        $this->content = $content;
+    }
+
+    public function getContent()
+    {
+        return $this->content;
+    }
+}

--- a/tests/UnitTest/Module/Core/Step/AddCnameTest.php
+++ b/tests/UnitTest/Module/Core/Step/AddCnameTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Couscous\Tests\UnitTest\Module\Template\Step;
+
+use Couscous\Model\Metadata;
+use Couscous\Model\Project;
+use Couscous\Module\Core\Step\AddCname;
+
+/**
+ * @covers \Couscous\Model\Project
+ */
+class AddCnameTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_add_the_cname_file()
+    {
+        $project = new Project('foo', 'bar');
+
+        $project->metadata = new Metadata();
+        $project->metadata['cname'] = 'http://www.couscous.io';
+
+        $step = new AddCname();
+        $step->__invoke($project);
+
+        $cnameFiles = $project->findFilesByType('Couscous\Module\Template\Model\CnameFile');
+
+        $this->assertCount(1, $cnameFiles);
+
+        $this->assertEquals($cnameFiles['CNAME']->content, $project->metadata['cname']);
+    }
+}

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,1 +1,0 @@
-couscous.io


### PR DESCRIPTION
This fixes the problem with CNAME and remote templates which is mentioned in the docs/configuration. Setting a `cname` metadata in `couscous.yml` generates a CNAME file.
