### PR TITLE
Add branch metadata to configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,9 @@ scripts:
     after:
         - rm website/couscous.phar
 
+# Set a target branch for deploying your couscous project
+branch: gh-pages
+
 # Any variable you put in this file is also available in the Twig layouts:
 title: Hello!
 

--- a/src/Application/Cli/DeployCommand.php
+++ b/src/Application/Cli/DeployCommand.php
@@ -82,7 +82,7 @@ class DeployCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Target branch in which to deploy the website.',
-                'gh-pages'
+                false
             );
     }
 
@@ -99,6 +99,11 @@ class DeployCommand extends Command
 
         // Generate the website
         $this->generator->generate($project, $output);
+
+        // Change the target branch if is needed
+        if (!$targetBranch) {
+            $targetBranch = isset($project->metadata['branch']) ? $project->metadata['branch'] : 'gh-pages';
+        }
 
         $output->writeln('');
 


### PR DESCRIPTION
Setting the branch metadata you can choose which branch to deploy.
Useful for deploying to a organization page. Fixes #133