### PR TITLE
Provide information about Github DDOS protection when using CURL to download Couscous.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,6 +30,8 @@ Alternatively, you can download [couscous.phar](http://couscous.io/couscous.phar
 $ curl -OS http://couscous.io/couscous.phar
 ```
 
+**Please note that as Github is using a DDOS protection system, if using CURL fails, just manually download the phar file.**
+
 If you want to run `couscous` instead of `php couscous.phar`, move it to `/usr/local/bin`:
 
 ```bash

--- a/website/home.twig
+++ b/website/home.twig
@@ -155,6 +155,7 @@
                     </p>
                     <pre trim><code>curl -OS http://couscous.io/couscous.phar
 php couscous.phar preview</code></pre>
+                    <p><strong>Please note that as Github is using a DDOS protection system, if using CURL fails, just manually download the phar file.</strong></p>
                     <p>
                         The website should be running at
                         <a href="http://localhost:8000/">http://localhost:8000/</a>


### PR DESCRIPTION
Resolve #131