### PR TITLE
Add Event implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /theme/
 /Vagrantfile
 /.vagrant
+.idea/

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "phine/phar": "~1.0",
         "mnapoli/front-yaml": "~1.5",
         "php-di/php-di": "^5.2.1",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "league/event": "^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5"

--- a/couscous.yml
+++ b/couscous.yml
@@ -13,6 +13,24 @@ scripts:
 baseUrl: http://couscous.io
 cname: couscous.io
 
+# This config is for demo purposes only. This will be removed when this feature will be merged.
+events:
+    listeners:
+        - event: 'couscous.step.after_config'
+          listener: 'Couscous\Event\Listener\AfterConfigListener'
+        - event: 'couscous.step.before_parse'
+          listener: 'Couscous\Event\Listener\BeforeParseListener'
+        - event: 'couscous.step.after_parse'
+          listener: 'Couscous\Event\Listener\AfterParseListener'
+        - event: 'couscous.step.before_render_markdown'
+          listener: 'Couscous\Event\Listener\BeforeRenderMarkdownListener'
+        - event: 'couscous.step.after_render_markdown'
+          listener: 'Couscous\Event\Listener\AfterRenderMarkdownListener'
+        - event: 'couscous.step.before_write'
+          listener: 'Couscous\Event\Listener\BeforeWriteListener'
+        - event: 'couscous.step.after_write'
+          listener: 'Couscous\Event\Listener\AfterWriteListener'
+
 menu:
     items:
         getting-started:

--- a/src/Application/config.php
+++ b/src/Application/config.php
@@ -10,6 +10,9 @@ return [
         DI\get('Couscous\Module\Config\Step\LoadConfig'),
         DI\get('Couscous\Module\Config\Step\OverrideBaseUrlForPreview'),
 
+        DI\get('Couscous\Module\Events\Step\InitEventListeners'),
+        DI\get('Couscous\Module\Events\Step\EmitAfterConfigEvent'),
+
         DI\get('Couscous\Module\Scripts\Step\ExecuteBeforeScripts'),
 
         DI\get('Couscous\Module\Template\Step\UseDefaultTemplate'),
@@ -25,17 +28,25 @@ return [
 
         DI\get('Couscous\Module\Core\Step\AddFileNameToMetadata'),
 
+        DI\get('Couscous\Module\Events\Step\EmitBeforeParseEvent'),
         DI\get('Couscous\Module\Markdown\Step\ParseMarkdownFrontMatter'),
+        DI\get('Couscous\Module\Events\Step\EmitAfterParseEvent'),
         DI\get('Couscous\Module\Markdown\Step\ProcessMarkdownFileName'),
         DI\get('Couscous\Module\Markdown\Step\RewriteMarkdownLinks'),
+        DI\get('Couscous\Module\Events\Step\EmitBeforeRenderMarkdownEvent'),
         DI\get('Couscous\Module\Markdown\Step\RenderMarkdown'),
+        DI\get('Couscous\Module\Events\Step\EmitAfterRenderMarkdownEvent'),
         DI\get('Couscous\Module\Markdown\Step\CreateHeadingIds'),
 
         DI\get('Couscous\Module\Template\Step\AddPageListToLayoutVariables'),
         DI\get('Couscous\Module\Template\Step\ProcessTwigLayouts'),
 
+        DI\get('Couscous\Module\Events\Step\EmitBeforeWriteEvent'),
+
         DI\get('Couscous\Module\Core\Step\ClearTargetDirectory'),
         DI\get('Couscous\Module\Core\Step\WriteFiles'),
+
+        DI\get('Couscous\Module\Events\Step\EmitAfterWriteEvent'),
 
         DI\get('Couscous\Module\Scripts\Step\ExecuteAfterScripts'),
     ],

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Couscous\Event;
+
+use DI\Container;
+use DI\ContainerBuilder;
+use League\Event\Emitter;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Eventmanager.
+ * Handles the event emitter.
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EventManager
+{
+    /**
+     * The emitter instance.
+     *
+     * @var Emitter
+     */
+    protected static $emitter;
+
+    /**
+     * Returns the static instance of the emitter.
+     *
+     * @return Emitter
+     */
+    public static function &emitter()
+    {
+        if(!self::$emitter) {
+            self::$emitter = new Emitter();
+        }
+        return self::$emitter;
+    }
+}

--- a/src/Event/Listener/AfterConfigListener.php
+++ b/src/Event/Listener/AfterConfigListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use League\Event\EventInterface;
+
+/**
+ * After Config Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class AfterConfigListener extends BaseListener
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     */
+    public function handle(EventInterface $event)
+    {
+        $project = func_get_arg(1)['project'];
+
+        var_dump('after_config');
+    }
+}

--- a/src/Event/Listener/AfterParseListener.php
+++ b/src/Event/Listener/AfterParseListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use League\Event\EventInterface;
+
+/**
+ * After Parse Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class AfterParseListener extends BaseListener
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     */
+    public function handle(EventInterface $event)
+    {
+        $project = func_get_arg(1)['project'];
+
+        var_dump('after_parse');
+    }
+}

--- a/src/Event/Listener/AfterRenderMarkdownListener.php
+++ b/src/Event/Listener/AfterRenderMarkdownListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use League\Event\EventInterface;
+
+/**
+ * After Render Markdown Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class AfterRenderMarkdownListener extends BaseListener
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     */
+    public function handle(EventInterface $event)
+    {
+        $project = func_get_arg(1)['project'];
+
+        var_dump('after_render_markdown');
+    }
+}

--- a/src/Event/Listener/AfterWriteListener.php
+++ b/src/Event/Listener/AfterWriteListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use League\Event\EventInterface;
+
+/**
+ * After Write Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class AfterWriteListener extends BaseListener
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     */
+    public function handle(EventInterface $event)
+    {
+        $project = func_get_arg(1)['project'];
+
+        var_dump('after_write');
+    }
+}

--- a/src/Event/Listener/BaseListener.php
+++ b/src/Event/Listener/BaseListener.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use DI\Container;
+use DI\ContainerBuilder;
+use League\Event\EventInterface;
+use League\Event\ListenerInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * Base Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class BaseListener implements ListenerInterface
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     *
+     * @return void
+     */
+    public function handle(EventInterface $event)
+    {
+    }
+
+    /**
+     * Check whether the listener is the given parameter.
+     *
+     * @param mixed $listener
+     *
+     * @return bool
+     */
+    public function isListener($listener)
+    {
+        return $listener === $this;
+    }
+}

--- a/src/Event/Listener/BeforeParseListener.php
+++ b/src/Event/Listener/BeforeParseListener.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use League\Event\EventInterface;
+
+/**
+ * Before Parse Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class BeforeParseListener extends BaseListener
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     */
+    public function handle(EventInterface $event)
+    {
+        $project = func_get_arg(1)['project'];
+
+        var_dump('before_parse');
+
+        /** @var MarkdownFile[] $markdownFiles */
+        $markdownFiles = $project->findFilesByType('Couscous\Module\Markdown\Model\MarkdownFile');
+
+        foreach ($markdownFiles as $file) {
+            $file->content = str_replace('Couscous', '**CakePlugins**', $file->content);
+        }
+    }
+}

--- a/src/Event/Listener/BeforeRenderMarkdownListener.php
+++ b/src/Event/Listener/BeforeRenderMarkdownListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use League\Event\EventInterface;
+
+/**
+ * Before Render Markdown Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class BeforeRenderMarkdownListener extends BaseListener
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     */
+    public function handle(EventInterface $event)
+    {
+        $project = func_get_arg(1)['project'];
+
+        var_dump('before_render_markdown');
+    }
+}

--- a/src/Event/Listener/BeforeWriteListener.php
+++ b/src/Event/Listener/BeforeWriteListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Couscous\Event\Listener;
+
+use Couscous\Model\Project;
+use Couscous\Step;
+use League\Event\EventInterface;
+
+/**
+ * Before Write Event Listener
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class BeforeWriteListener extends BaseListener
+{
+
+    /**
+     * Handle the event.
+     *
+     * @param EventInterface $event
+     */
+    public function handle(EventInterface $event)
+    {
+        $project = func_get_arg(1)['project'];
+
+        var_dump('before_write');
+    }
+}

--- a/src/Module/Events/Step/EmitAfterConfigEvent.php
+++ b/src/Module/Events/Step/EmitAfterConfigEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Fire the event couscous.step.after_config.
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EmitAfterConfigEvent implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+        $emitter->emit('couscous.step.after_config', ['project' => $project]);
+    }
+}

--- a/src/Module/Events/Step/EmitAfterParseEvent.php
+++ b/src/Module/Events/Step/EmitAfterParseEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Fire the event couscous.step.after_parse.
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EmitAfterParseEvent implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+        $emitter->emit('couscous.step.after_parse', ['project' => $project]);
+    }
+}

--- a/src/Module/Events/Step/EmitAfterRenderMarkdownEvent.php
+++ b/src/Module/Events/Step/EmitAfterRenderMarkdownEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Fire the event couscous.step.after_render_markdown
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EmitAfterRenderMarkdownEvent implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+        $emitter->emit('couscous.step.after_render_markdown', ['project' => $project]);
+    }
+}

--- a/src/Module/Events/Step/EmitAfterWriteEvent.php
+++ b/src/Module/Events/Step/EmitAfterWriteEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Fire the event couscous.step.after_write
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EmitAfterWriteEvent implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+        $emitter->emit('couscous.step.after_write', ['project' => $project]);
+    }
+}

--- a/src/Module/Events/Step/EmitBeforeParseEvent.php
+++ b/src/Module/Events/Step/EmitBeforeParseEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Fire the event couscous.step.before_parse
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EmitBeforeParseEvent implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+        $emitter->emit('couscous.step.before_parse', ['project' => $project]);
+    }
+}

--- a/src/Module/Events/Step/EmitBeforeRenderMarkdownEvent.php
+++ b/src/Module/Events/Step/EmitBeforeRenderMarkdownEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Fire the event couscous.step.before_render_markdown
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EmitBeforeRenderMarkdownEvent implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+        $emitter->emit('couscous.step.before_render_markdown', ['project' => $project]);
+    }
+}

--- a/src/Module/Events/Step/EmitBeforeWriteEvent.php
+++ b/src/Module/Events/Step/EmitBeforeWriteEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Fire the event couscous.step.before_write
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class EmitBeforeWriteEvent implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+        $emitter->emit('couscous.step.before_write', ['project' => $project]);
+    }
+}

--- a/src/Module/Events/Step/InitEventListeners.php
+++ b/src/Module/Events/Step/InitEventListeners.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Couscous\Module\Events\Step;
+
+use Couscous\Event\EventManager;
+use Couscous\Model\Project;
+use Couscous\Step;
+
+/**
+ * Initializes all listeners from the config to the emitter.
+ *
+ * @author Bob Mulder <bobmulder@outlook.com>
+ */
+class InitEventListeners implements Step
+{
+    public function __invoke(Project $project)
+    {
+        $emitter = EventManager::emitter();
+
+        $listeners = (array)$project->metadata['events.listeners'];
+
+        foreach ($listeners as $listener) {
+            $emitter->addListener(
+                $listener['event'],
+                new $listener['listener'],
+                array_key_exists('priority', $listener) ? $listener['priority'] : null
+            );
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

I know we have had this discussion before, but today I've created a small and simple implementation of events in Couscous. 

I want to open this PR to share the idea for now. When you agree with this feature I will add tests and documentation.

For using events I have used the library of ThePHPLeauge: http://event.thephpleague.com/2.0/

The following events are supported:
        - `couscous.step.after_config`
        - `couscous.step.before_parse`
        - `couscous.step.after_parse`
        - `couscous.step.before_render_markdown`
        - `couscous.step.after_render_markdown`
        - `couscous.step.before_write`
        - `couscous.step.after_write`

To show you where the event exactly has been fired, I have implemented one listener per event with a `var_dump()` with the event-name in it.
In every event, the `$project` variable is accessible. However because a bug in the Event-library (which is fixed in https://github.com/thephpleague/event/pull/66) it's a bit dirty now, but soon it will be better ;)
To show you that it becomes very easy to customize the markdown process I have replaced the word `couscous` to `CakePlugins`.

This feature would be very helpful to extend Couscous locally. This is very helpfull when you want to work with small features who can't be realized quickely in the Couscous library.
In future we could extend this feature by using external events from external resources loaded via Composer.

I would like to know how you think about this!


