### PR TITLE
Add support for following symlinks

### DIFF
--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -124,6 +124,7 @@ class Project
 
         $finder = new Finder();
         $finder->files()
+            ->followLinks()
             ->in(!empty($includedDirectories) ? $includedDirectories : $this->sourceDirectory)
             ->ignoreDotFiles(true)
             ->exclude(array_merge($excludedDirectories, ['.couscous']));


### PR DESCRIPTION
Pretty self-explanatory. 

No tests as I think we should be trusting Finder to honour its contract as it's a 3rd party library.