### PR TITLE
Add http:// prefix to preview URI

### DIFF
--- a/src/Application/Cli/PreviewCommand.php
+++ b/src/Application/Cli/PreviewCommand.php
@@ -141,7 +141,7 @@ class PreviewCommand extends Command
         $process = $builder->getProcess();
         $process->start();
 
-        $output->writeln(sprintf('Server running on <comment>%s</comment>', $input->getArgument('address')));
+        $output->writeln(sprintf('Server running on <comment>http://%s</comment>', $input->getArgument('address')));
 
         return $process;
     }


### PR DESCRIPTION
Many terminal emulators support clicking on URIs and automatically opening them in a browser - adding the protocol to the server address allows this link detection to work correctly.

Tested in OS X Terminal.app and iTerm2.app, both of which now handle the link correctly (by cmd+doubleclicking and cmd+clicking respectively) where they did not before the change.