### PR TITLE
Display error output when the server goes down

### DIFF
--- a/src/Application/Cli/PreviewCommand.php
+++ b/src/Application/Cli/PreviewCommand.php
@@ -112,7 +112,7 @@ class PreviewCommand extends Command
             sleep(1);
         }
 
-        throw new RuntimeException('The HTTP server has stopped');
+        throw new RuntimeException('The HTTP server has stopped: '.PHP_EOL.$serverProcess->getErrorOutput());
     }
 
     private function generateWebsite(


### PR DESCRIPTION
When using the `preview` command, sometimes the server stops and we have
no clue about the problem. Adding the process error output will help
users understand what's happening.

<img width="1095" alt="capture d ecran 2016-05-30 a 14 19 55" src="https://cloud.githubusercontent.com/assets/327237/15649413/a4d0f6b4-2671-11e6-855a-f5fee1712726.png">