### PR TITLE
Makes default pages boxed instead of full-width

### DIFF
--- a/website/default.twig
+++ b/website/default.twig
@@ -59,7 +59,7 @@
 
     {% block content %}
 
-        <div class="container-fluid">
+        <div class="container">
             <div class="row">
 
                 <nav id="sidebar" class="col-sm-3 col-lg-2" role="navigation">
@@ -76,7 +76,7 @@
 
                 </nav>
 
-                <section class="documentation col-sm-offset-3 col-lg-offset-2 col-sm-9 col-lg-10">
+                <section class="documentation col-sm-offset-3 col-lg-offset-3 col-sm-9 col-lg-10">
                     {{ content|raw }}
                 </section>
 

--- a/website/less/sidebar.less
+++ b/website/less/sidebar.less
@@ -2,6 +2,7 @@
   #sidebar {
     position: fixed;
     margin-top: 50px;
+    padding-right: 35px;
   }
 }
 


### PR DESCRIPTION
This PR makes the documentation and other text-based pages boxed instead of full-width. This is much cleaner and friendlier to read.

It's a small change, but it's something ;P