### PR TITLE
Read excluded directories from the `.gitignore` file of the repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ To be able to preview Couscous own website on your machine, you will need the fo
 - Less compiler:
 
     ```
-    $ npm install -g less
+    $ npm install -g less less-plugin-clean-css
     ```
 
 - Phar generation enabled in `php.ini`:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,6 +29,8 @@ exclude:
     - vendor
     - website
     - some/dir
+    # This special entry will ask Couscous to read the exluded directories from your ".gitignore"  file
+    - %gitignore%
 
 scripts:
     # Scripts to execute before generating the website

--- a/src/Model/ExcludeList.php
+++ b/src/Model/ExcludeList.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Couscous\Model;
+
+use Symfony\Component\Finder\Finder;
+
+class ExcludeList
+{
+    /**
+     * @var string[]
+     */
+    private $excluded;
+
+    public function __construct(array $exclude = [])
+    {
+        $this->excluded = $exclude;
+    }
+
+    public function addEntry($entry)
+    {
+        $this->excluded[] = $entry;
+
+        return $this;
+    }
+
+    public function addEntries(array $entries)
+    {
+        $this->excluded = array_merge($this->excluded, $entries);
+
+        return $this;
+    }
+
+    public function contains($needle)
+    {
+        return in_array($needle, $this->excluded);
+    }
+
+    public function toArray()
+    {
+        $excluded = $this->excluded;
+        $excluded = array_filter($excluded, [$this, 'keepEntry']);
+        $excluded = array_map([$this, 'sanitizeEntry'], $excluded);
+        $excluded = array_map(function ($entry) {
+            return trim($entry, '/');
+        }, $excluded);
+
+        return array_values(array_unique($excluded));
+    }
+
+    public function excludeFromFinder(Finder $finder)
+    {
+        $finder->exclude($this->toArray());
+
+        return $this;
+    }
+
+    private function keepEntry($entry)
+    {
+        switch (true) {
+            case !is_string($entry) && !is_numeric($entry):
+            case $entry === '':
+            case preg_match('/^[#!]/', $entry) > 0:
+            case strpos($entry, '*') !== false:
+                return false;
+
+            default:
+                return true;
+        }
+    }
+
+    private function sanitizeEntry($entry)
+    {
+        return preg_replace(
+            '/\\\(\s)$/',
+            '$1',
+            preg_replace(
+                '/(?<!\\\)(\s)$/',
+                '',
+                $entry
+            )
+        );
+    }
+}

--- a/src/Model/Project.php
+++ b/src/Model/Project.php
@@ -120,14 +120,21 @@ class Project
             });
         }
 
-        $excludedDirectories = $this->metadata['exclude'] ? $this->metadata['exclude'] : [];
+        $excludedDirectories = new ExcludeList($this->metadata['exclude'] ? $this->metadata['exclude'] : []);
+
+        if (is_file($this->sourceDirectory.'/.gitignore')) {
+            $excludedDirectories->addEntries(file($this->sourceDirectory.'/.gitignore'));
+        }
 
         $finder = new Finder();
         $finder->files()
             ->followLinks()
             ->in(!empty($includedDirectories) ? $includedDirectories : $this->sourceDirectory)
-            ->ignoreDotFiles(true)
-            ->exclude(array_merge($excludedDirectories, ['.couscous']));
+            ->ignoreDotFiles(true);
+
+        $excludedDirectories
+            ->addEntry('.couscous')
+            ->excludeFromFinder($finder);
 
         return $finder;
     }

--- a/tests/UnitTest/Model/ExcludeListTest.php
+++ b/tests/UnitTest/Model/ExcludeListTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Couscous\Tests\UnitTest\Model;
+
+use Couscous\Model\ExcludeList;
+
+/**
+ * @covers \Couscous\Model\ExcludeList
+ */
+class ExcludeListTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_init_with_excluded_entries()
+    {
+        $excluded = new ExcludeList(['foo', 'bar']);
+
+        $this->assertSame(['foo', 'bar'], $excluded->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_store_additional_entry()
+    {
+        $excluded = new ExcludeList(['foo', 'bar']);
+        $excluded->addEntry('baz');
+
+        $this->assertSame(['foo', 'bar', 'baz'], $excluded->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_store_additional_entries()
+    {
+        $excluded = new ExcludeList(['foo', 'bar']);
+        $excluded->addEntries(['baz', 'boo']);
+
+        $this->assertSame(['foo', 'bar', 'baz', 'boo'], $excluded->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_dedupe_entries()
+    {
+        $excluded = new ExcludeList(['foo', 'bar', 'baz']);
+        $excluded->addEntry('foo');
+        $excluded->addEntries(['baz', 'boo']);
+
+        $this->assertSame(['foo', 'bar', 'baz', 'boo'], $excluded->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_filter_invalid_entries()
+    {
+        $excluded = new ExcludeList(['foo', '', 'bar']);
+        $excluded->addEntry('');
+        $excluded->addEntries(['baz', '', null, true, false, 1337]);
+
+        $this->assertSame(['foo', 'bar', 'baz', '1337'], $excluded->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_filter_special_entries()
+    {
+        $excluded = new ExcludeList(['foo', '#foo', 'bar', '!bar', '*.php', 'foo/**/bar.php']);
+
+        $this->assertSame(['foo', 'bar'], $excluded->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_sanitize_entries()
+    {
+        $excluded = new ExcludeList(['foo', 'bar ', "baz\t", 'boo\ ']);
+
+        $this->assertSame(['foo', 'bar', 'baz', 'boo '], $excluded->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_exclude_from_finder()
+    {
+        $finder = $this->getMockBuilder('Symfony\Component\Finder\Finder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $finder->expects($this->once())->method('exclude')->with(['foo', 'bar', '1337']);
+
+        $excluded = new ExcludeList(['foo', '#foo', 'bar', '!bar', '', 1337, null]);
+        $excluded->excludeFromFinder($finder);
+    }
+}


### PR DESCRIPTION
This allows users to have their git ignored files and directories automatically
ignored by Couscous. To enable this feature, they will have to add the special
`%gitignore%` entry to their exclude list.

Why do we use a special entry? To keep the actual behavior unchanged and avoid
unexpected generation errors.

The actual implementation is a bit naïve: it will take each entry line from the
`.gitignore` and add them to the exclude list of Couscous. So we might end up
adding files and directories. It's hard to test every `.gitignore` entry to see
if the are actual directories: paths might be relative or patterns, starting
from the repository's root directory or not.

Moreover, the implementation does not support complex pattern as git would.