### PR TITLE
Add documentation for self-update command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,3 +88,11 @@ $ couscous deploy --branch master
 ## Customizing the template
 
 Couscous provides [a default template](https://github.com/CouscousPHP/Template-Light) (and a [few others to choose from](http://couscous.io/templates.html)), but you can of course come up with your own. Writing templates is really simple, and it is all explained in the [templates documentation](templates.md).
+
+## Updating Couscous
+
+If you are using the phar file, you can update Couscous by simply running the `self-update` command:
+
+```bash
+$ couscous self-update
+```


### PR DESCRIPTION
I noticed that there wasn't anything on the website about the new `self-update` command, so here's an addition to point it out.

Feel free to move this somewhere else. There wasn't really an existing page that talked about Couscous _itself,_ but maybe there should be?