### PR TITLE
Extend Metadata with YAML data files defined in configuration (#174)

### DIFF
--- a/src/Module/Config/Step/LoadConfig.php
+++ b/src/Module/Config/Step/LoadConfig.php
@@ -51,6 +51,12 @@ class LoadConfig implements Step
         }
 
         $metadata = $this->parseYamlFile($filename);
+
+        if (array_key_exists('dataFiles', $metadata)) {
+            // Extend configuration with extra data files.
+            $metadata['dataFiles'] = $this->loadDataFiles($metadata['dataFiles'], $project->sourceDirectory);
+        }
+
         $metadata = $this->validateConfig($metadata);
 
         $project->metadata->setMany($metadata);
@@ -98,5 +104,24 @@ class LoadConfig implements Step
         }
 
         return $values;
+    }
+
+    /**
+     * Load extra data files defined in configuration file.
+     *
+     * @param  array $dataFiles     Array of data files to load.
+     * @param  string $relativeTo   Path from where files will be resolved.
+     *
+     * @return array                Array - key,value - of loaded data.
+     */
+    private function loadDataFiles($dataFiles, $relativeTo)
+    {
+        $loadedData = array();
+        foreach ($dataFiles as $key => $dataFile) {
+            // Load this data file.
+            $loadedData["$key"] = $this->parseYamlFile($relativeTo . DIRECTORY_SEPARATOR . $dataFile);
+        }
+
+        return $loadedData;
     }
 }


### PR DESCRIPTION
I took the liberty to implement a first attempt at mimicking Jekyll `_data` directory by loading files in configuration as if it was included in `couscous.yml`.

It works by defining the `dataFiles` in your `couscous.yml`:

```yml
...
# List of files to parse and load into the configuration and make available to twig templates by their key
# Paths are relative to the optional source path given when generating the website, repository root by default
dataFiles:
  myCustomFile: data/my-custom-file.yml
  otherFile: data/other-file.yml
...
```

Path to those files are resolved related to project source directory, repository root by default. You can then use values in any twig templates by their keys, as if it was defined in the `couscous.yml` file itself.

- [x] Load YAML files
- [ ] Load JSON files
- [ ] Load CSV files

See #174 for more informations.