### PR TITLE
Bump Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
         "bin/couscous"
     ],
     "require": {
-        "php": ">=5.4.0",
-        "symfony/console": "~2.6|~3.0|~4.0",
-        "symfony/filesystem": "~2.6|~3.0|~4.0",
-        "symfony/finder": "~2.6|~3.0|~4.0",
-        "symfony/process": "~2.6|~3.0|~4.0",
-        "symfony/yaml": "~2.6|~3.0|~4.0",
+        "php": ">=5.6.0",
+        "symfony/console": "~3.0|~4.0",
+        "symfony/filesystem": "~3.0|~4.0",
+        "symfony/finder": "~3.0|~4.0",
+        "symfony/process": "~3.0|~4.0",
+        "symfony/yaml": "~3.0|~4.0",
         "twig/twig": "~1.10",
         "erusev/parsedown": "~1.6.4",
         "erusev/parsedown-extra": "~0.7",
@@ -36,7 +36,7 @@
     },
     "config": {
         "platform": {
-            "php": "5.4"
+            "php": "5.6"
         }
     }
 }


### PR DESCRIPTION
Bumping the Symfony version fixes #227 . Not really sure what the actual issue is, it could also be fixed by passing a string to the Symfony Process in the preview command:

```
    private function startWebServer(InputInterface $input, OutputInterface $output, $targetDirectory)
    {
        $processArguments = [PHP_BINARY, '-S', $input->getArgument('address')];

        $process = new Process($processArguments);
```

but that will be deprecated in the Process component anyway I think.