### PR TITLE
Fix command issues with windows

### DIFF
--- a/src/CommandRunner/CommandRunner.php
+++ b/src/CommandRunner/CommandRunner.php
@@ -21,7 +21,11 @@ class CommandRunner
      */
     public function run($command)
     {
-        exec($command.' 2>&1', $output, $returnValue);
+        if (PHP_OS == 'WINNT') {
+            exec($command, $output, $returnValue);
+        } else {
+            exec($command . ' 2>&1', $output, $returnValue);
+        }
 
         $output = implode(PHP_EOL, $output);
 

--- a/src/CommandRunner/CommandRunner.php
+++ b/src/CommandRunner/CommandRunner.php
@@ -21,7 +21,7 @@ class CommandRunner
      */
     public function run($command)
     {
-        if (PHP_OS == 'WINNT') {
+        if (PHP_OS === 'WINNT') {
             exec($command, $output, $returnValue);
         } else {
             exec($command . ' 2>&1', $output, $returnValue);


### PR DESCRIPTION
Couscous is not compatible with windows because of this exec command:

```php
exec($command . ' 2>&1', $output, $returnValue);
```

The `couscous deploy` command crashes under windows:

```
Generating C:\...\Couscous\bin to C:\...\Couscous\bin/.couscous/generated
[notice] No couscous.yml configuration file found, using default config
[notice] Fetching template from https://github.com/CouscousPHP/Template-Light.git

Deploying the website
Cloning https://github.com/CouscousPHP/Couscous.git in C:\Users\...\Temp\couDDAD.tmp
Checking out branch gh-pages
Copying generated website
Committing changes
Pushing gh-pages (GitHub may ask you to login)

In CommandRunner.php line 29:
                                                                     
  fatal: HttpRequestException encountered.                           
     Fehler beim Senden der Anforderung.                             
  bash: /dev/tty: No such device or address                          
  error: failed to execute prompt script (exit code 1)               
  fatal: could not read Username for 'https://github.com': No error  
                                                                     
deploy [--repository REPOSITORY] [--branch BRANCH] [--config CONFIG] [--] [<source>]
```

This fix makes the commands compatible with windows and will not break the existing behavior for Linux users. Tested on my windows computer.