### PR TITLE
Upgrade to PHP 7.1 and fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
@@ -13,10 +11,10 @@ cache:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env:
         - dependencies=lowest
-    - php: 7.0
+    - php: 7.1
       env:
         - DEPLOY_WEBSITE=true
 
@@ -39,5 +37,5 @@ deploy:
   on:
     repo: CouscousPHP/Couscous
     tags: true
-    php: '7.0'
+    php: '7.1'
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "bin/couscous"
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.1",
         "symfony/console": "~3.0|~4.0",
         "symfony/filesystem": "~3.0|~4.0",
         "symfony/finder": "~3.0|~4.0",
@@ -31,12 +31,12 @@
         "padraic/phar-updater": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
+        "phpunit/phpunit": "~7.5",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "config": {
         "platform": {
-            "php": "5.6"
+            "php": "7.1"
         }
     }
 }

--- a/docs/travis.md
+++ b/docs/travis.md
@@ -49,9 +49,7 @@ Here is an example of what your `.travis.yml` might look like. This assumes **yo
 ```yml
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
+  - 7.3
 env:
   global:
     - GIT_NAME: "'Couscous auto deploy'"

--- a/src/Application/Cli/TravisAutoDeployCommand.php
+++ b/src/Application/Cli/TravisAutoDeployCommand.php
@@ -62,7 +62,7 @@ class TravisAutoDeployCommand extends Command
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Specify for which php version you want to deploy documentation, mainly to avoid multiple deploys',
-                '7.0'
+                '7.1'
             )
             ->addOption(
                 'branch',

--- a/tests/FunctionalTest/BaseFunctionalTest.php
+++ b/tests/FunctionalTest/BaseFunctionalTest.php
@@ -2,11 +2,12 @@
 
 namespace Couscous\Tests\FunctionalTest;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-abstract class BaseFunctionalTest extends \PHPUnit_Framework_TestCase
+abstract class BaseFunctionalTest extends TestCase
 {
     protected $generatedDirectory;
 

--- a/tests/FunctionalTest/CommandRunner/CommandRunnerTest.php
+++ b/tests/FunctionalTest/CommandRunner/CommandRunnerTest.php
@@ -3,11 +3,12 @@
 namespace Couscous\Tests\FunctionalTest\CommandRunner;
 
 use Couscous\CommandRunner\CommandRunner;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Couscous\CommandRunner\CommandRunner
+ * @covers \Couscous\CommandRunner\CommandRunner
  */
-class CommandRunnerTest extends \PHPUnit_Framework_TestCase
+class CommandRunnerTest extends TestCase
 {
     /**
      * @var CommandRunner

--- a/tests/UnitTest/CommandRunner/GitTest.php
+++ b/tests/UnitTest/CommandRunner/GitTest.php
@@ -4,12 +4,13 @@ namespace Couscous\Tests\UnitTest\CommandRunner;
 
 use Couscous\CommandRunner\CommandRunner;
 use Couscous\CommandRunner\Git;
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * @covers \Couscous\CommandRunner\Git
  */
-class GitTest extends \PHPUnit_Framework_TestCase
+class GitTest extends TestCase
 {
     /**
      * @var Git
@@ -25,7 +26,7 @@ class GitTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->commandRunner = $this->getMock('Couscous\CommandRunner\CommandRunner');
+        $this->commandRunner = $this->createMock('Couscous\CommandRunner\CommandRunner');
         $this->git = new Git($this->commandRunner);
     }
 

--- a/tests/UnitTest/GeneratorTest.php
+++ b/tests/UnitTest/GeneratorTest.php
@@ -5,13 +5,14 @@ namespace Couscous\Tests\UnitTest;
 use Couscous\Generator;
 use Couscous\Model\Project;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers \Couscous\Generator
  */
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+class GeneratorTest extends TestCase
 {
     /**
      * @test
@@ -37,7 +38,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
      */
     private function createFilesystem()
     {
-        return $this->getMock('Symfony\Component\Filesystem\Filesystem');
+        return $this->createMock('Symfony\Component\Filesystem\Filesystem');
     }
 
     private function createStep(Project $project)

--- a/tests/UnitTest/Model/ExcludeListTest.php
+++ b/tests/UnitTest/Model/ExcludeListTest.php
@@ -3,11 +3,12 @@
 namespace Couscous\Tests\UnitTest\Model;
 
 use Couscous\Model\ExcludeList;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Model\ExcludeList
  */
-class ExcludeListTest extends \PHPUnit_Framework_TestCase
+class ExcludeListTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Model/FileTest.php
+++ b/tests/UnitTest/Model/FileTest.php
@@ -3,19 +3,23 @@
 namespace Couscous\Tests\UnitTest\Model;
 
 use Couscous\Model\File;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Model\File
  */
-class FileTest extends \PHPUnit_Framework_TestCase
+class FileTest extends TestCase
 {
     /**
      * @test
      */
     public function it_should_have_metadata()
     {
-        /** @var File $file */
-        $file = $this->getMock('Couscous\Model\File', ['getContent'], ['test.md']);
+        $file = new class('') extends File {
+            public function getContent()
+            {
+            }
+        };
 
         $file->getMetadata()['foo'] = 'test';
         $this->assertEquals('test', $file->getMetadata()['foo']);

--- a/tests/UnitTest/Model/MetadataTest.php
+++ b/tests/UnitTest/Model/MetadataTest.php
@@ -3,11 +3,12 @@
 namespace Couscous\Tests\UnitTest\Model;
 
 use Couscous\Model\Metadata;
+use PHPUnit\Framework\TestCase;
 
 /**
- * @covers Couscous\Model\Metadata
+ * @covers \Couscous\Model\Metadata
  */
-class MetadataTest extends \PHPUnit_Framework_TestCase
+class MetadataTest extends TestCase
 {
     private $values;
 

--- a/tests/UnitTest/Model/ProjectTest.php
+++ b/tests/UnitTest/Model/ProjectTest.php
@@ -6,11 +6,12 @@ use Couscous\Model\File;
 use Couscous\Model\Project;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Module\Template\Model\HtmlFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Model\Project
  */
-class ProjectTest extends \PHPUnit_Framework_TestCase
+class ProjectTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Module/Config/Step/OverrideBaseUrlForPreviewTest.php
+++ b/tests/UnitTest/Module/Config/Step/OverrideBaseUrlForPreviewTest.php
@@ -4,11 +4,12 @@ namespace Couscous\Tests\UnitTest\Module\Config\Step;
 
 use Couscous\Module\Config\Step\OverrideBaseUrlForPreview;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Module\Config\Step\OverrideBaseUrlForPreview
  */
-class OverrideBaseUrlForPreviewTest extends \PHPUnit_Framework_TestCase
+class OverrideBaseUrlForPreviewTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Module/Config/Step/OverrideConfigFromCLITest.php
+++ b/tests/UnitTest/Module/Config/Step/OverrideConfigFromCLITest.php
@@ -4,11 +4,12 @@ namespace Couscous\Tests\UnitTest\Module\Config\Step;
 
 use Couscous\Module\Config\Step\OverrideConfigFromCLI;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Module\Config\Step\OverrideConfigFromCLI
  */
-class OverrideConfigFromCLITest extends \PHPUnit_Framework_TestCase
+class OverrideConfigFromCLITest extends TestCase
 {
     /**
      * @test
@@ -19,7 +20,7 @@ class OverrideConfigFromCLITest extends \PHPUnit_Framework_TestCase
         $project->metadata['title'] = 'foo';
         $project->metadata['cliConfig'] = ['title=bar'];
 
-        $logger = $this->getMock("Psr\Log\LoggerInterface");
+        $logger = $this->createMock("Psr\Log\LoggerInterface");
 
         $step = new OverrideConfigFromCLI($logger);
         $step->__invoke($project);
@@ -36,7 +37,7 @@ class OverrideConfigFromCLITest extends \PHPUnit_Framework_TestCase
         $project->metadata['title'] = 'foo';
         $project->metadata['cliConfig'] = [];
 
-        $logger = $this->getMock("Psr\Log\LoggerInterface");
+        $logger = $this->createMock("Psr\Log\LoggerInterface");
 
         $step = new OverrideConfigFromCLI($logger);
         $step->__invoke($project);
@@ -52,7 +53,7 @@ class OverrideConfigFromCLITest extends \PHPUnit_Framework_TestCase
         $project = new MockProject();
         $project->metadata['title'] = 'foo';
 
-        $logger = $this->getMock("Psr\Log\LoggerInterface");
+        $logger = $this->createMock("Psr\Log\LoggerInterface");
 
         $step = new OverrideConfigFromCLI($logger);
         $step->__invoke($project);

--- a/tests/UnitTest/Module/Config/Step/SetDefaultConfigTest.php
+++ b/tests/UnitTest/Module/Config/Step/SetDefaultConfigTest.php
@@ -4,11 +4,12 @@ namespace Couscous\Tests\UnitTest\Module\Config\Step;
 
 use Couscous\Module\Config\Step\SetDefaultConfig;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Module\Config\Step\SetDefaultConfig
  */
-class SetDefaultConfigTest extends \PHPUnit_Framework_TestCase
+class SetDefaultConfigTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Module/Core/Step/AddCnameTest.php
+++ b/tests/UnitTest/Module/Core/Step/AddCnameTest.php
@@ -5,11 +5,12 @@ namespace Couscous\Tests\UnitTest\Module\Core\Step;
 use Couscous\Model\Metadata;
 use Couscous\Model\Project;
 use Couscous\Module\Core\Step\AddCname;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Model\Project
  */
-class AddCnameTest extends \PHPUnit_Framework_TestCase
+class AddCnameTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Module/Core/Step/AddFileNameToMetadataTest.php
+++ b/tests/UnitTest/Module/Core/Step/AddFileNameToMetadataTest.php
@@ -5,11 +5,12 @@ namespace Couscous\Tests\UnitTest\Module\Core\Step;
 use Couscous\Module\Core\Step\AddFileNameToMetadata;
 use Couscous\Module\Template\Model\HtmlFile;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Module\Core\Step\AddFileNameToMetadata
  */
-class AddFileNameToMetadataTest extends \PHPUnit_Framework_TestCase
+class AddFileNameToMetadataTest extends TestCase
 {
     /**
      * @test

--- a/tests/UnitTest/Module/Core/Step/ClearTargetDirectoryTest.php
+++ b/tests/UnitTest/Module/Core/Step/ClearTargetDirectoryTest.php
@@ -4,13 +4,14 @@ namespace Couscous\Tests\UnitTest\Module\Core\Step;
 
 use Couscous\Model\Project;
 use Couscous\Module\Core\Step\ClearTargetDirectory;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 /**
  * @covers \Couscous\Model\Project
  */
-class ClearTargetDirectoryTest extends \PHPUnit_Framework_TestCase
+class ClearTargetDirectoryTest extends TestCase
 {
     /**
      * Dot files like .travis.yaml or .github/workflows/action.yml should not be removed.
@@ -18,7 +19,7 @@ class ClearTargetDirectoryTest extends \PHPUnit_Framework_TestCase
      */
     public function it_should_not_clear_dot_files()
     {
-        $project = new Project('foo', dirname(dirname(dirname(__DIR__,))).'/Fixture/directory-with-dot-files');
+        $project = new Project('foo', dirname(__DIR__, 3) .'/Fixture/directory-with-dot-files');
 
         $filesystem = $this->getMockBuilder(Filesystem::class)
             ->disableOriginalConstructor()

--- a/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/ProcessMarkdownFileNameTest.php
@@ -7,11 +7,12 @@ use Couscous\Model\Metadata;
 use Couscous\Model\Project;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Module\Markdown\Step\ProcessMarkdownFileName;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Module\Markdown\Step\ProcessMarkdownFileName
  */
-class ProcessMarkdownFileNameTest extends \PHPUnit_Framework_TestCase
+class ProcessMarkdownFileNameTest extends TestCase
 {
     public function testRenameExtension()
     {

--- a/tests/UnitTest/Module/Markdown/Step/RenderMarkdownTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/RenderMarkdownTest.php
@@ -6,13 +6,14 @@ use Couscous\Application\ContainerFactory;
 use Couscous\Model\Project;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Module\Markdown\Step\RenderMarkdown;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test supported Markdown features.
  *
  * @author Matthieu Napoli <matthieu@mnapoli.fr>
  */
-class RenderMarkdownTest extends \PHPUnit_Framework_TestCase
+class RenderMarkdownTest extends TestCase
 {
     /**
      * Test that classic Markdown is supported.

--- a/tests/UnitTest/Module/Markdown/Step/RewriteMarkdownLinksTest.php
+++ b/tests/UnitTest/Module/Markdown/Step/RewriteMarkdownLinksTest.php
@@ -5,11 +5,12 @@ namespace Couscous\Tests\UnitTest\Module\Markdown\Step;
 use Couscous\Model\Project;
 use Couscous\Module\Markdown\Model\MarkdownFile;
 use Couscous\Module\Markdown\Step\RewriteMarkdownLinks;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Module\Markdown\Step\RewriteMarkdownLinks
  */
-class RewriteMarkdownLinksTest extends \PHPUnit_Framework_TestCase
+class RewriteMarkdownLinksTest extends TestCase
 {
     public function testReplaceLinks()
     {

--- a/tests/UnitTest/Module/Template/Step/AddPageListToTemplateVariablesTest.php
+++ b/tests/UnitTest/Module/Template/Step/AddPageListToTemplateVariablesTest.php
@@ -6,11 +6,12 @@ use Couscous\Model\Project;
 use Couscous\Module\Template\Model\HtmlFile;
 use Couscous\Module\Template\Step\AddPageListToLayoutVariables;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \Couscous\Module\Template\Step\AddPageListToLayoutVariables
  */
-class AddPageListToTemplateVariablesTest extends \PHPUnit_Framework_TestCase
+class AddPageListToTemplateVariablesTest extends TestCase
 {
     private function files()
     {

--- a/tests/UnitTest/Module/Template/Step/FetchRemoteTemplateTest.php
+++ b/tests/UnitTest/Module/Template/Step/FetchRemoteTemplateTest.php
@@ -2,22 +2,25 @@
 
 namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
+use Couscous\CommandRunner\Git;
 use Couscous\Module\Template\Step\FetchRemoteTemplate;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers \Couscous\Module\Template\Step\FetchRemoteTemplate
  */
-class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
+class FetchRemoteTemplateTest extends TestCase
 {
     /**
      * @test
      */
     public function it_should_skip_if_no_template_url()
     {
-        $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
-        $git = $this->getMock('Couscous\CommandRunner\Git', [], [], '', false);
+        $filesystem = $this->createMock(Filesystem::class);
+        $git = $this->createMock(Git::class);
 
         $step = new FetchRemoteTemplate($filesystem, new NullLogger(), $git);
 
@@ -36,8 +39,8 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
      */
     public function it_should_clone_and_set_the_template_directory()
     {
-        $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
-        $git = $this->getMock('Couscous\CommandRunner\Git', [], [], '', false);
+        $filesystem = $this->createMock(Filesystem::class);
+        $git = $this->createMock(Git::class);
 
         $step = new FetchRemoteTemplate($filesystem, new NullLogger(), $git);
 
@@ -58,8 +61,8 @@ class FetchRemoteTemplateTest extends \PHPUnit_Framework_TestCase
      */
     public function it_should_not_clone_twice_if_regenerating()
     {
-        $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
-        $git = $this->getMock('Couscous\CommandRunner\Git', [], [], '', false);
+        $filesystem = $this->createMock(Filesystem::class);
+        $git = $this->createMock(Git::class);
 
         $step = new FetchRemoteTemplate($filesystem, new NullLogger(), $git);
 

--- a/tests/UnitTest/Module/Template/Step/UseDefaultTemplateTest.php
+++ b/tests/UnitTest/Module/Template/Step/UseDefaultTemplateTest.php
@@ -4,12 +4,13 @@ namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\UseDefaultTemplate;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers \Couscous\Module\Template\Step\UseDefaultTemplate
  */
-class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
+class UseDefaultTemplateTest extends TestCase
 {
     /**
      * @test
@@ -73,7 +74,7 @@ class UseDefaultTemplateTest extends \PHPUnit_Framework_TestCase
      */
     private function createFilesystem($return = false)
     {
-        $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem');
+        $filesystem = $this->createMock('Symfony\Component\Filesystem\Filesystem');
         $filesystem->expects($this->any())
             ->method('exists')
             ->willReturn($return);

--- a/tests/UnitTest/Module/Template/Step/ValidateTemplateDirectoryTest.php
+++ b/tests/UnitTest/Module/Template/Step/ValidateTemplateDirectoryTest.php
@@ -4,12 +4,13 @@ namespace Couscous\Tests\UnitTest\Module\Template\Step;
 
 use Couscous\Module\Template\Step\ValidateTemplateDirectory;
 use Couscous\Tests\UnitTest\Mock\MockProject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @covers \Couscous\Module\Template\Step\ValidateTemplateDirectory
  */
-class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
+class ValidateTemplateDirectoryTest extends TestCase
 {
     /**
      * @test
@@ -94,15 +95,19 @@ class ValidateTemplateDirectoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Filesystem
+     * @return Filesystem
      */
     private function createFilesystem($existsShouldReturn = true)
     {
-        $filesystem = $this->getMock('Symfony\Component\Filesystem\Filesystem', ['exists']);
-        $filesystem->expects($this->any())
-            ->method('exists')
-            ->willReturn($existsShouldReturn);
-
-        return $filesystem;
+        return new class($existsShouldReturn) extends Filesystem {
+            public function __construct($existsShouldReturn)
+            {
+                $this->existsShouldReturn = $existsShouldReturn;
+            }
+            public function exists($files)
+            {
+                return $this->existsShouldReturn;
+            }
+        };
     }
 }


### PR DESCRIPTION
This PR drops support for PHP 5.6 and 7.0.

Supporting these versions was too much effort in order to fix the build.