### PR TITLE
[Doc] The .gitignore file is always read

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,12 +25,11 @@ include:
 
 # List of directories to exclude from the processing (default contains "vendor" and "website")
 # Paths are relative to the optional include paths given when generating the website, repository root by default
+# The ".gitignore" file will also be read if it exists to exclude the directories in it
 exclude:
     - vendor
     - website
     - some/dir
-    # This special entry will ask Couscous to read the exluded directories from your ".gitignore"  file
-    - %gitignore%
 
 scripts:
     # Scripts to execute before generating the website


### PR DESCRIPTION
If we take the code here:
https://github.com/CouscousPHP/Couscous/blob/c168d0b9c1449d60f2a31b2a30c7ab7e61e419be/src/Model/Project.php#L127-L129
We see the `.gitignore` file is always read.
This PR changes the documentation to mention it correctly.