### PR TITLE
Add support to override template properties from command line

### DIFF
--- a/src/Module/Config/Step/OverrideConfigFromCLI.php
+++ b/src/Module/Config/Step/OverrideConfigFromCLI.php
@@ -33,10 +33,16 @@ class OverrideConfigFromCLI implements Step
         $cliConfig = [];
         /** @var string $item */
         foreach ($project->metadata['cliConfig'] as $item) {
-            $explosion = explode('=', $item, 2);
-            $this->logger->notice('Overriding global config: '.$explosion[0].' = "'.$explosion[1].'"');
+            $setting = explode('=', $item, 2);
+            $this->logger->notice('Overriding global config: '.$setting[0].' = "'.$setting[1].'"');
 
-            $cliConfig[$explosion[0]] = $explosion[1];
+            $settingKey = explode('.', $setting[0]);
+            $settingValue = $setting[1];
+            foreach (array_reverse($settingKey) as $valueAsKey) {
+                $settingValue = [$valueAsKey => $settingValue];
+            }
+
+            $cliConfig = array_merge($cliConfig, $settingValue);
         }
 
         unset($project->metadata['cliConfig']);

--- a/tests/UnitTest/Module/Config/Step/OverrideConfigFromCLITest.php
+++ b/tests/UnitTest/Module/Config/Step/OverrideConfigFromCLITest.php
@@ -60,4 +60,22 @@ class OverrideConfigFromCLITest extends TestCase
 
         $this->assertEquals('foo', $project->metadata['title']);
     }
+
+    /**
+     * @test
+     */
+    public function should_override_template_url()
+    {
+        $project = new MockProject();
+        $project->metadata['title'] = 'foo';
+        $project->metadata['template'] = ['url' => 'https://github.com/template.git'];
+        $project->metadata['cliConfig'] = ['template.url=https://gitlab.com/template.git'];
+        $logger = $this->createMock("Psr\Log\LoggerInterface");
+        $step = new OverrideConfigFromCLI($logger);
+
+        $step->__invoke($project);
+
+        $this->assertEquals('foo', $project->metadata['title']);
+        $this->assertEquals('https://gitlab.com/template.git', $project->metadata['template']['url']);
+    }
 }


### PR DESCRIPTION
- Allow overriding `template.url` or `template.directory` from command line

For example

```bash
bin/couscous preview --config template.url=https://github.com/CouscousPHP/Template-Dark.git
```

As mentioned in this issue comment: https://github.com/CouscousPHP/Couscous/issues/159#issuecomment-439488113